### PR TITLE
Generate unique key for lines for avoid useless re-rendering with react.js

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +484,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +725,18 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "heck"
@@ -976,6 +1006,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1247,7 @@ dependencies = [
 name = "patto"
 version = "0.1.14"
 dependencies = [
+ "anyhow",
  "axum",
  "chrono",
  "clap",
@@ -1220,12 +1261,15 @@ dependencies = [
  "notify",
  "pest",
  "pest_derive",
+ "rand",
  "regex",
  "reqwest",
  "ropey",
+ "rusqlite",
  "rust-embed",
  "serde",
  "serde_json",
+ "sha2",
  "simplelog",
  "str_indices",
  "thiserror",
@@ -1492,6 +1536,20 @@ checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
 dependencies = [
  "smallvec",
  "str_indices",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.6.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,18 +484,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,18 +713,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown",
-]
 
 [[package]]
 name = "heck"
@@ -1006,16 +982,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsqlite3-sys"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
-dependencies = [
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,7 +1231,6 @@ dependencies = [
  "regex",
  "reqwest",
  "ropey",
- "rusqlite",
  "rust-embed",
  "serde",
  "serde_json",
@@ -1536,20 +1501,6 @@ checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
 dependencies = [
  "smallvec",
  "str_indices",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
-dependencies = [
- "bitflags 2.6.0",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ tokio = { version = "1.17.0", features = ["full"] }
 tower-lsp = { version = "0.20.0", features = ["runtime-tokio", "proposed"]}
 url = "2.5.2"
 urlencoding = "2.1.3"
+rusqlite = "0.32.1"
+sha2 = "0.10.8"
+anyhow = "1.0.88"
+rand = "0.8.5"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ tokio = { version = "1.17.0", features = ["full"] }
 tower-lsp = { version = "0.20.0", features = ["runtime-tokio", "proposed"]}
 url = "2.5.2"
 urlencoding = "2.1.3"
-rusqlite = "0.32.1"
 sha2 = "0.10.8"
 anyhow = "1.0.88"
 rand = "0.8.5"

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ use std::process::Command;
 
 fn main() {
     let frontend_dir = "patto-preview-next/";
+    let watch_dir = "patto-preview-next/src/";
 
     #[cfg(windows)]
     const NPM: &str = "npm.cmd"; // Or "npm.ps1" if you're explicitly using PowerShell
@@ -9,7 +10,7 @@ fn main() {
     const NPM: &str = "npm";
 
     // Only rerun build script if something in the frontend changes
-    println!("cargo:rerun-if-changed={}", frontend_dir);
+    println!("cargo:rerun-if-changed={}", watch_dir);
 
     // Run `npm install`
     let status = Command::new(NPM)

--- a/src/bin/patto-html-renderer.rs
+++ b/src/bin/patto-html-renderer.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>>{
     let args = Cli::parse();
     // TODO memory inefficient
     let text = fs::read_to_string(&args.file).expect("cannot read {filename}");
-    let parser::ParserResult { ast: rootnode, parse_errors: _ } = parser::parse_text_with_line_tracking(&text, &args.file.to_string_lossy());
+    let parser::ParserResult { ast: rootnode, parse_errors: _ } = parser::parse_text(&text);
 
     let mut writer = BufWriter::new(fs::File::create(args.output).unwrap());
     let options = renderer::Options {

--- a/src/bin/patto-html-renderer.rs
+++ b/src/bin/patto-html-renderer.rs
@@ -49,8 +49,8 @@ fn init_logger(filter_level: log::LevelFilter, logfile: Option<PathBuf>) {
 fn main() -> Result<(), Box<dyn std::error::Error>>{
     let args = Cli::parse();
     // TODO memory inefficient
-    let text = fs::read_to_string(args.file).expect("cannot read {filename}");
-    let parser::ParserResult { ast: rootnode, parse_errors: _ } = parser::parse_text(&text);
+    let text = fs::read_to_string(&args.file).expect("cannot read {filename}");
+    let parser::ParserResult { ast: rootnode, parse_errors: _ } = parser::parse_text_with_line_tracking(&text, &args.file.to_string_lossy());
 
     let mut writer = BufWriter::new(fs::File::create(args.output).unwrap());
     let options = renderer::Options {

--- a/src/bin/patto-preview.rs
+++ b/src/bin/patto-preview.rs
@@ -11,7 +11,8 @@ use clap::Parser;
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
 use patto::{
     parser,
-    renderer::{HtmlRenderer, Options, Renderer}
+    renderer::{HtmlRenderer, Options, Renderer},
+    line_tracker::LineTracker
 };
 use rust_embed::RustEmbed;
 use std::path::{Path, PathBuf};
@@ -57,6 +58,7 @@ struct Args {
 struct AppState {
     dir: PathBuf,
     tx: broadcast::Sender<Message>,
+    line_trackers: Arc<Mutex<HashMap<PathBuf, LineTracker>>>,
 }
 
 // Messages for the broadcast channel
@@ -185,6 +187,7 @@ async fn main() {
     let state = AppState {
         dir: dir.clone(),
         tx: tx.clone(),
+        line_trackers: Arc::new(Mutex::new(HashMap::new())),
     };
 
     // Start file watcher in a separate task
@@ -513,7 +516,7 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                             // Load and render the selected file
                             let file_path = state.dir.join(&path);
                             if let Ok(content) = fs::read_to_string(&file_path).await {
-                                if let Ok(html) = render_patto_to_html(&content, &file_path.to_string_lossy()).await {
+                                if let Ok(html) = render_patto_to_html(&content, &file_path.to_string_lossy(), &state).await {
                                     // Send the rendered HTML to the client
                                     let message = WsMessage::FileChanged {
                                         path: path.clone(),
@@ -749,7 +752,7 @@ async fn process_file_change(state: &AppState, path: &Path) -> std::io::Result<(
 
     // Parse and render to HTML
     let start = Instant::now();
-    let html = render_patto_to_html(&content, &path.to_string_lossy()).await?;
+    let html = render_patto_to_html(&content, &path.to_string_lossy(), state).await?;
 
     // Generate relative path
     let rel_path = path.strip_prefix(&state.dir).unwrap_or(path);
@@ -763,16 +766,25 @@ async fn process_file_change(state: &AppState, path: &Path) -> std::io::Result<(
     Ok(())
 }
 
-// Render patto content to HTML
-async fn render_patto_to_html(content: &str, file_path: &str) -> std::io::Result<String> {
+// Render patto content to HTML with persistent line tracking
+async fn render_patto_to_html(content: &str, file_path: &str, state: &AppState) -> std::io::Result<String> {
     // Use Arc to avoid cloning large content
     let content = std::sync::Arc::new(content.to_string());
-    let file_path = std::sync::Arc::new(file_path.to_string());
+    let file_path_buf = PathBuf::from(file_path);
+    
+    // Get or create line tracker for this file
+    let line_trackers = Arc::clone(&state.line_trackers);
     
     let html_output = tokio::task::spawn_blocking(move || {
-        //let start = Instant::now();
-        let result = parser::parse_text_with_line_tracking(&content, &file_path);
-        //println!("-- Parsed, taking {} msec.", start.elapsed().as_millis());
+        // Get or create line tracker for this file
+        let mut trackers = line_trackers.lock().unwrap();
+        let line_tracker = trackers.entry(file_path_buf.clone()).or_insert_with(|| {
+            LineTracker::new().unwrap_or_else(|_| {
+                panic!();
+            })
+        });
+        
+        let result = parser::parse_text_with_persistent_line_tracking(&content, line_tracker);
         
         // Pre-allocate buffer with estimated size to reduce reallocations
         let estimated_size = content.len() * 2; // HTML is typically 2x larger than source
@@ -782,9 +794,7 @@ async fn render_patto_to_html(content: &str, file_path: &str) -> std::io::Result
             ..Options::default()
         });
         
-        //let start = Instant::now();
         let _ = renderer.format(&result.ast, &mut html_output);
-        //println!("-- Rendered, taking {} msec.", start.elapsed().as_millis());
         html_output
     }).await;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ pub mod parser;
 pub mod renderer;
 pub mod utils;
 pub mod semantic_token;
+pub mod line_tracker;

--- a/src/line_tracker.rs
+++ b/src/line_tracker.rs
@@ -1,198 +1,109 @@
-use rusqlite::{Connection, params};
 use std::collections::{HashMap, HashSet};
-use sha2::{Digest, Sha256};
-use chrono::Utc;
-use anyhow::Result;
+use std::hash::{Hash, Hasher};
+use std::collections::hash_map::DefaultHasher;
+use std::time::Instant;
 
 pub struct LineTracker {
-    file_path: String,
-    db_connection: Connection,
+    content_to_id: HashMap<u64, Vec<i64>>,
+    position_to_id: HashMap<usize, i64>,
+    next_id: i64,
     line_ids: Vec<i64>,
 }
 
 impl LineTracker {
-    pub fn new(file_path: &str) -> Result<Self> {
-        let mut db_path = std::env::temp_dir(); 
-        db_path.push("patto_line_tracker.db");
-        let conn = Connection::open(&db_path)?;
-        Self::init(file_path, conn)
-    }
-
-    pub fn new_in_memory(file_path: &str) -> Result<Self> {
-        let conn = Connection::open_in_memory()?;
-        Self::init(file_path, conn)
-    }
-
-    fn init(file_path: &str, conn: Connection) -> Result<Self> {
-        // Initialize database schema if needed
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS lines (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                file_path TEXT NOT NULL,
-                current_content TEXT NOT NULL,
-                content_hash TEXT NOT NULL,
-                is_active BOOLEAN NOT NULL DEFAULT 1,
-                last_known_line_number INTEGER,
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL
-            );
-            CREATE INDEX IF NOT EXISTS idx_file_content ON lines (file_path, content_hash);
-            CREATE INDEX IF NOT EXISTS idx_file_active ON lines (file_path, is_active);"
-        )?;
-
+    pub fn new() -> anyhow::Result<Self> {
         Ok(LineTracker {
-            file_path: file_path.to_string(),
-            db_connection: conn,
+            content_to_id: HashMap::new(),
+            position_to_id: HashMap::new(),
+            next_id: 1,
             line_ids: Vec::new(),
         })
     }
 
-    pub fn process_file_content(&mut self, content: &str) -> Result<Vec<i64>> {
-        let tx = self.db_connection.transaction()?;
-        let current_time = Utc::now().to_rfc3339();
-
-        // Pre-compute line data in single pass
+    pub fn process_file_content(&mut self, content: &str) -> anyhow::Result<Vec<i64>> {
         let lines: Vec<&str> = content.lines().collect();
-        let line_data: Vec<(String, String)> = lines.iter()
+        
+        // Fast hash computation using default hasher
+        let line_hashes: Vec<u64> = lines.iter()
             .map(|line| {
-                let trimmed = line.trim();
-                (trimmed.to_string(), generate_content_hash(trimmed))
+                let mut hasher = DefaultHasher::new();
+                line.trim().hash(&mut hasher);
+                hasher.finish()
             })
             .collect();
 
-        // Single query to get existing data
-        let mut existing_by_hash: HashMap<String, Vec<i64>> = HashMap::new();
-        let mut existing_by_pos: HashMap<i64, (i64, String)> = HashMap::new();
-        
-        {
-            let mut stmt = tx.prepare(
-                "SELECT id, content_hash, last_known_line_number FROM lines 
-                 WHERE file_path = ? AND is_active = 1"
-            )?;
-            let rows = stmt.query_map(params![&self.file_path], |row| {
-                Ok((
-                    row.get::<_, i64>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, Option<i64>>(2)?
-                ))
-            })?;
-            
-            for row in rows {
-                let (id, hash, pos) = row?;
-                existing_by_hash.entry(hash.clone()).or_default().push(id);
-                if let Some(p) = pos {
-                    existing_by_pos.insert(p, (id, hash));
-                }
-            }
-        }
-
-        // Assign IDs efficiently
+        let mut new_content_to_id: HashMap<u64, Vec<i64>> = HashMap::new();
+        let mut new_position_to_id: HashMap<usize, i64> = HashMap::new();
         let mut used_ids: HashSet<i64> = HashSet::new();
         let mut result_ids = Vec::with_capacity(lines.len());
-        let mut batch_updates: Vec<(i64, String, i64)> = Vec::new();
-        let mut batch_inserts: Vec<(String, String, i64)> = Vec::new();
-        
-        for (idx, (content, hash)) in line_data.iter().enumerate() {
-            let line_num = (idx + 1) as i64;
+
+        let start = Instant::now();
+        // Assign IDs with simple in-memory logic
+        for (idx, &hash) in line_hashes.iter().enumerate() {
+            let line_num = idx + 1;
             
-            let id = if let Some((existing_id, existing_hash)) = existing_by_pos.get(&line_num) {
-                if existing_hash == hash && !used_ids.contains(existing_id) {
-                    // Perfect match at same position
-                    batch_updates.push((*existing_id, content.clone(), line_num));
-                    used_ids.insert(*existing_id);
-                    *existing_id
+            let id = if let Some(&existing_id) = self.position_to_id.get(&line_num) {
+                // Same position exists
+                if let Some(existing_hash) = self.get_hash_for_position(line_num) {
+                    if existing_hash == hash {
+                        // Same content at same position - reuse ID
+                        used_ids.insert(existing_id);
+                        existing_id
+                    } else {
+                        // Different content at same position - find reusable ID
+                        self.find_or_create_id(hash, &mut used_ids, &mut new_content_to_id)
+                    }
                 } else {
-                    // Position exists but content changed - find reusable ID
-                    Self::find_reusable_id(hash, &existing_by_hash, &mut used_ids, 
-                                           &mut batch_updates, &mut batch_inserts, 
-                                           content, line_num)
+                    // Position exists but no hash (shouldn't happen)
+                    self.find_or_create_id(hash, &mut used_ids, &mut new_content_to_id)
                 }
             } else {
                 // New position
-                Self::find_reusable_id(hash, &existing_by_hash, &mut used_ids,
-                                       &mut batch_updates, &mut batch_inserts,
-                                       content, line_num)
+                self.find_or_create_id(hash, &mut used_ids, &mut new_content_to_id)
             };
-            
+
+            new_content_to_id.entry(hash).or_default().push(id);
+            new_position_to_id.insert(line_num, id);
             result_ids.push(id);
         }
+        println!("-- b: {} ms", start.elapsed().as_millis());
 
-        // Execute batch operations
-        if !batch_updates.is_empty() {
-            let mut stmt = tx.prepare(
-                "UPDATE lines SET current_content = ?, last_known_line_number = ?, updated_at = ? 
-                 WHERE id = ?"
-            )?;
-            for (id, content, pos) in batch_updates {
-                stmt.execute(params![content, pos, current_time, id])?;
-            }
-        }
-
-        // Handle inserts (need individual execution for ID retrieval)
-        if !batch_inserts.is_empty() {
-            let mut stmt = tx.prepare(
-                "INSERT INTO lines (file_path, current_content, content_hash, is_active, 
-                 last_known_line_number, created_at, updated_at) 
-                 VALUES (?, ?, ?, 1, ?, ?, ?)"
-            )?;
-            
-            let mut insert_idx = 0;
-            for i in 0..result_ids.len() {
-                if result_ids[i] == 0 { // Placeholder for new insert
-                    let (content, hash, pos) = &batch_inserts[insert_idx];
-                    stmt.execute(params![
-                        &self.file_path, content, hash, pos, current_time, current_time
-                    ])?;
-                    result_ids[i] = tx.last_insert_rowid();
-                    insert_idx += 1;
-                }
-            }
-        }
-
-        // Batch deactivate unused lines
-        let all_existing: HashSet<i64> = existing_by_hash.values().flatten().copied().collect();
-        let unused: Vec<i64> = all_existing.difference(&used_ids).copied().collect();
-        
-        if !unused.is_empty() {
-            let placeholders = unused.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-            let query = format!(
-                "UPDATE lines SET is_active = 0, updated_at = ? WHERE id IN ({})", 
-                placeholders
-            );
-            let mut params_vec = vec![&current_time as &dyn rusqlite::ToSql];
-            for id in &unused {
-                params_vec.push(id as &dyn rusqlite::ToSql);
-            }
-            tx.execute(&query, params_vec.as_slice())?;
-        }
-
-        tx.commit()?;
+        // Update internal state
+        self.content_to_id = new_content_to_id;
+        self.position_to_id = new_position_to_id;
         self.line_ids = result_ids.clone();
+        
         Ok(result_ids)
     }
 
-    fn find_reusable_id(
-        hash: &str,
-        existing_by_hash: &HashMap<String, Vec<i64>>,
-        used_ids: &mut HashSet<i64>,
-        batch_updates: &mut Vec<(i64, String, i64)>,
-        batch_inserts: &mut Vec<(String, String, i64)>,
-        content: &str,
-        line_num: i64,
-    ) -> i64 {
-        if let Some(ids) = existing_by_hash.get(hash) {
-            for &id in ids {
+    fn get_hash_for_position(&self, position: usize) -> Option<u64> {
+        if let Some(&id) = self.position_to_id.get(&position) {
+            // Find hash for this ID
+            for (&hash, ids) in &self.content_to_id {
+                if ids.contains(&id) {
+                    return Some(hash);
+                }
+            }
+        }
+        None
+    }
+
+    fn find_or_create_id(&mut self, hash: u64, used_ids: &mut HashSet<i64>, new_content_to_id: &mut HashMap<u64, Vec<i64>>) -> i64 {
+        // Try to reuse existing ID for this content
+        if let Some(existing_ids) = self.content_to_id.get(&hash) {
+            for &id in existing_ids {
                 if !used_ids.contains(&id) {
-                    batch_updates.push((id, content.to_string(), line_num));
                     used_ids.insert(id);
                     return id;
                 }
             }
         }
-        
-        // No reusable ID found - mark for insert
-        batch_inserts.push((content.to_string(), hash.to_string(), line_num));
-        0 // Placeholder - will be replaced with actual ID after insert
+
+        // No reusable ID found - create new one
+        let new_id = self.next_id;
+        self.next_id += 1;
+        used_ids.insert(new_id);
+        new_id
     }
 
     pub fn get_line_id(&self, line_number: usize) -> Option<i64> {
@@ -204,20 +115,14 @@ impl LineTracker {
     }
 }
 
-fn generate_content_hash(content: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(content.as_bytes());
-    format!("{:x}", hasher.finalize())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_line_tracking_basic() -> Result<()> {
+    fn test_line_tracking_basic() -> anyhow::Result<()> {
         let test_content = "Line 1\nLine 2\nLine 3\n";
-        let mut tracker = LineTracker::new_in_memory("test_file.txt")?;
+        let mut tracker = LineTracker::new()?;
         
         let ids = tracker.process_file_content(test_content)?;
         assert_eq!(ids.len(), 3);
@@ -231,8 +136,8 @@ mod tests {
     }
 
     #[test]
-    fn test_line_tracking_reuse() -> Result<()> {
-        let mut tracker = LineTracker::new_in_memory("test_file2.txt")?;
+    fn test_line_tracking_reuse() -> anyhow::Result<()> {
+        let mut tracker = LineTracker::new()?;
         
         // First version
         let content1 = "Hello\nWorld\n";

--- a/src/line_tracker.rs
+++ b/src/line_tracker.rs
@@ -49,7 +49,7 @@ impl LineTracker {
 
             let id = if hash == hash_for_empty {
                 // id can be the same for empty lines
-                -1 as i64
+                -1
             } else if let Some(&existing_id) = self.position_to_id.get(&line_num) {
                 // Same position exists
                 if let Some(existing_hash) = self.line_hashes.get(idx) {

--- a/src/line_tracker.rs
+++ b/src/line_tracker.rs
@@ -1,19 +1,8 @@
 use rusqlite::{Connection, params};
 use std::collections::{HashMap, HashSet};
-// use std::io::{BufReader, BufRead};
 use sha2::{Digest, Sha256};
 use chrono::Utc;
 use anyhow::Result;
-use Drop;
-
-#[derive(Debug, Clone)]
-struct TrackedLine {
-    id: i64,
-    content: String,
-    hash: String,
-    is_active: bool,
-    last_known_line_number: Option<i64>,
-}
 
 pub struct LineTracker {
     file_path: String,
@@ -56,131 +45,154 @@ impl LineTracker {
             db_connection: conn,
             line_ids: Vec::new(),
         })
-
     }
 
     pub fn process_file_content(&mut self, content: &str) -> Result<Vec<i64>> {
         let tx = self.db_connection.transaction()?;
-        let current_time_str = Utc::now().to_rfc3339();
+        let current_time = Utc::now().to_rfc3339();
 
-        // Get all currently active lines for this file
-        let old_active_lines_by_order: HashMap<i64, TrackedLine>;
-        let old_active_hashes_to_ids: HashMap<String, Vec<i64>>;
-        let old_active_ids: HashSet<i64>;
+        // Pre-compute line data in single pass
+        let lines: Vec<&str> = content.lines().collect();
+        let line_data: Vec<(String, String)> = lines.iter()
+            .map(|line| {
+                let trimmed = line.trim();
+                (trimmed.to_string(), generate_content_hash(trimmed))
+            })
+            .collect();
 
+        // Single query to get existing data
+        let mut existing_by_hash: HashMap<String, Vec<i64>> = HashMap::new();
+        let mut existing_by_pos: HashMap<i64, (i64, String)> = HashMap::new();
+        
         {
             let mut stmt = tx.prepare(
-                "SELECT id, current_content, content_hash, is_active, last_known_line_number 
-                 FROM lines WHERE file_path = ? AND is_active = 1 
-                 ORDER BY last_known_line_number ASC"
+                "SELECT id, content_hash, last_known_line_number FROM lines 
+                 WHERE file_path = ? AND is_active = 1"
             )?;
-            let active_lines_iter = stmt.query_map(params![&self.file_path], |row| {
-                let line = TrackedLine {
-                    id: row.get(0)?,
-                    content: row.get(1)?,
-                    hash: row.get(2)?,
-                    is_active: row.get(3)?,
-                    last_known_line_number: row.get(4)?,
-                };
-                Ok(line)
+            let rows = stmt.query_map(params![&self.file_path], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<i64>>(2)?
+                ))
             })?;
-
-            let mut temp_lines_by_order = HashMap::new();
-            let mut temp_hashes_to_ids: HashMap<_, Vec<i64>> = HashMap::new();
-            let mut temp_ids = HashSet::new();
-
-            for line_result in active_lines_iter {
-                let line = line_result?;
-                if let Some(order) = line.last_known_line_number {
-                    temp_lines_by_order.insert(order, line.clone());
+            
+            for row in rows {
+                let (id, hash, pos) = row?;
+                existing_by_hash.entry(hash.clone()).or_default().push(id);
+                if let Some(p) = pos {
+                    existing_by_pos.insert(p, (id, hash));
                 }
-                temp_hashes_to_ids.entry(line.hash.clone()).or_default().push(line.id);
-                temp_ids.insert(line.id);
             }
-            old_active_lines_by_order = temp_lines_by_order;
-            old_active_hashes_to_ids = temp_hashes_to_ids;
-            old_active_ids = temp_ids;
         }
 
-        // Process the current file content line by line
-        let mut matched_current_run_ids: HashSet<i64> = HashSet::new();
-        let mut result_line_ids: Vec<i64> = Vec::new();
+        // Assign IDs efficiently
+        let mut used_ids: HashSet<i64> = HashSet::new();
+        let mut result_ids = Vec::with_capacity(lines.len());
+        let mut batch_updates: Vec<(i64, String, i64)> = Vec::new();
+        let mut batch_inserts: Vec<(String, String, i64)> = Vec::new();
+        
+        for (idx, (content, hash)) in line_data.iter().enumerate() {
+            let line_num = (idx + 1) as i64;
+            
+            let id = if let Some((existing_id, existing_hash)) = existing_by_pos.get(&line_num) {
+                if existing_hash == hash && !used_ids.contains(existing_id) {
+                    // Perfect match at same position
+                    batch_updates.push((*existing_id, content.clone(), line_num));
+                    used_ids.insert(*existing_id);
+                    *existing_id
+                } else {
+                    // Position exists but content changed - find reusable ID
+                    Self::find_reusable_id(hash, &existing_by_hash, &mut used_ids, 
+                                           &mut batch_updates, &mut batch_inserts, 
+                                           content, line_num)
+                }
+            } else {
+                // New position
+                Self::find_reusable_id(hash, &existing_by_hash, &mut used_ids,
+                                       &mut batch_updates, &mut batch_inserts,
+                                       content, line_num)
+            };
+            
+            result_ids.push(id);
+        }
 
-        {
-            let mut insert_stmt = tx.prepare_cached(
-                "INSERT INTO lines (file_path, current_content, content_hash, is_active, last_known_line_number, created_at, updated_at)
+        // Execute batch operations
+        if !batch_updates.is_empty() {
+            let mut stmt = tx.prepare(
+                "UPDATE lines SET current_content = ?, last_known_line_number = ?, updated_at = ? 
+                 WHERE id = ?"
+            )?;
+            for (id, content, pos) in batch_updates {
+                stmt.execute(params![content, pos, current_time, id])?;
+            }
+        }
+
+        // Handle inserts (need individual execution for ID retrieval)
+        if !batch_inserts.is_empty() {
+            let mut stmt = tx.prepare(
+                "INSERT INTO lines (file_path, current_content, content_hash, is_active, 
+                 last_known_line_number, created_at, updated_at) 
                  VALUES (?, ?, ?, 1, ?, ?, ?)"
             )?;
-            let mut update_stmt = tx.prepare_cached(
-                "UPDATE lines SET current_content = ?, is_active = 1, last_known_line_number = ?, updated_at = ? WHERE id = ?"
-            )?;
-
-            for (line_num_0_idx, line) in content.lines().enumerate() {
-                let current_line_num = (line_num_0_idx + 1) as i64;
-                let trimmed_content = line.trim();
-                let content_hash = generate_content_hash(trimmed_content);
-
-                let mut found_match = false;
-                let mut line_id: i64 = 0;
-
-                // Check if content is at the same position with same hash
-                if let Some(old_line_at_pos) = old_active_lines_by_order.get(&current_line_num) {
-                    if old_line_at_pos.hash == content_hash {
-                        update_stmt.execute(
-                            params![trimmed_content, current_line_num, current_time_str, old_line_at_pos.id]
-                        )?;
-                        matched_current_run_ids.insert(old_line_at_pos.id);
-                        line_id = old_line_at_pos.id;
-                        found_match = true;
-                    }
-                }
-
-                // If not matched at current position, check if this content exists elsewhere
-                if !found_match {
-                    let mut matched_id_for_reuse: Option<i64> = None;
-                    if let Some(ids_for_hash) = old_active_hashes_to_ids.get(&content_hash) {
-                        for &id in ids_for_hash {
-                            if old_active_ids.contains(&id) && !matched_current_run_ids.contains(&id) {
-                                matched_id_for_reuse = Some(id);
-                                break;
-                            }
-                        }
-                    }
-
-                    if let Some(id_to_reuse) = matched_id_for_reuse {
-                        update_stmt.execute(
-                            params![trimmed_content, current_line_num, current_time_str, id_to_reuse]
-                        )?;
-                        matched_current_run_ids.insert(id_to_reuse);
-                        line_id = id_to_reuse;
-                    } else {
-                        insert_stmt.execute(
-                            params![&self.file_path, trimmed_content, content_hash, current_line_num, current_time_str, current_time_str]
-                        )?;
-                        let new_id = tx.last_insert_rowid();
-                        matched_current_run_ids.insert(new_id);
-                        line_id = new_id;
-                    }
-                }
-
-                result_line_ids.push(line_id);
-            }
-
-            // Deactivate lines that are no longer in the file
-            let mut deactivate_stmt = tx.prepare_cached(
-                "UPDATE lines SET is_active = 0, updated_at = ? WHERE id = ?"
-            )?;
-
-            for &old_id in &old_active_ids {
-                if !matched_current_run_ids.contains(&old_id) {
-                    deactivate_stmt.execute(params![current_time_str, old_id])?;
+            
+            let mut insert_idx = 0;
+            for i in 0..result_ids.len() {
+                if result_ids[i] == 0 { // Placeholder for new insert
+                    let (content, hash, pos) = &batch_inserts[insert_idx];
+                    stmt.execute(params![
+                        &self.file_path, content, hash, pos, current_time, current_time
+                    ])?;
+                    result_ids[i] = tx.last_insert_rowid();
+                    insert_idx += 1;
                 }
             }
+        }
+
+        // Batch deactivate unused lines
+        let all_existing: HashSet<i64> = existing_by_hash.values().flatten().copied().collect();
+        let unused: Vec<i64> = all_existing.difference(&used_ids).copied().collect();
+        
+        if !unused.is_empty() {
+            let placeholders = unused.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+            let query = format!(
+                "UPDATE lines SET is_active = 0, updated_at = ? WHERE id IN ({})", 
+                placeholders
+            );
+            let mut params_vec = vec![&current_time as &dyn rusqlite::ToSql];
+            for id in &unused {
+                params_vec.push(id as &dyn rusqlite::ToSql);
+            }
+            tx.execute(&query, params_vec.as_slice())?;
         }
 
         tx.commit()?;
-        self.line_ids = result_line_ids.clone();
-        Ok(result_line_ids)
+        self.line_ids = result_ids.clone();
+        Ok(result_ids)
+    }
+
+    fn find_reusable_id(
+        hash: &str,
+        existing_by_hash: &HashMap<String, Vec<i64>>,
+        used_ids: &mut HashSet<i64>,
+        batch_updates: &mut Vec<(i64, String, i64)>,
+        batch_inserts: &mut Vec<(String, String, i64)>,
+        content: &str,
+        line_num: i64,
+    ) -> i64 {
+        if let Some(ids) = existing_by_hash.get(hash) {
+            for &id in ids {
+                if !used_ids.contains(&id) {
+                    batch_updates.push((id, content.to_string(), line_num));
+                    used_ids.insert(id);
+                    return id;
+                }
+            }
+        }
+        
+        // No reusable ID found - mark for insert
+        batch_inserts.push((content.to_string(), hash.to_string(), line_num));
+        0 // Placeholder - will be replaced with actual ID after insert
     }
 
     pub fn get_line_id(&self, line_number: usize) -> Option<i64> {
@@ -192,16 +204,9 @@ impl LineTracker {
     }
 }
 
-// impl Drop for LineTracker {
-//     fn drop(&mut self) {
-//         self.db_connection.close();
-//     }
-// }
-
 fn generate_content_hash(content: &str) -> String {
-    let normalized_line = content.trim();
     let mut hasher = Sha256::new();
-    hasher.update(normalized_line.as_bytes());
+    hasher.update(content.as_bytes());
     format!("{:x}", hasher.finalize())
 }
 

--- a/src/line_tracker.rs
+++ b/src/line_tracker.rs
@@ -1,0 +1,246 @@
+use rusqlite::{Connection, params};
+use std::collections::{HashMap, HashSet};
+// use std::io::{BufReader, BufRead};
+use sha2::{Digest, Sha256};
+use chrono::Utc;
+use anyhow::Result;
+use Drop;
+
+#[derive(Debug, Clone)]
+struct TrackedLine {
+    id: i64,
+    content: String,
+    hash: String,
+    is_active: bool,
+    last_known_line_number: Option<i64>,
+}
+
+pub struct LineTracker {
+    file_path: String,
+    db_connection: Connection,
+    line_ids: Vec<i64>,
+}
+
+impl LineTracker {
+    pub fn new(file_path: &str) -> Result<Self> {
+        let mut db_path = std::env::temp_dir(); 
+        db_path.push("patto_line_tracker.db");
+        let conn = Connection::open(&db_path)?;
+        Self::init(file_path, conn)
+    }
+
+    pub fn new_in_memory(file_path: &str) -> Result<Self> {
+        let conn = Connection::open_in_memory()?;
+        Self::init(file_path, conn)
+    }
+
+    fn init(file_path: &str, conn: Connection) -> Result<Self> {
+        // Initialize database schema if needed
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS lines (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT NOT NULL,
+                current_content TEXT NOT NULL,
+                content_hash TEXT NOT NULL,
+                is_active BOOLEAN NOT NULL DEFAULT 1,
+                last_known_line_number INTEGER,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_file_content ON lines (file_path, content_hash);
+            CREATE INDEX IF NOT EXISTS idx_file_active ON lines (file_path, is_active);"
+        )?;
+
+        Ok(LineTracker {
+            file_path: file_path.to_string(),
+            db_connection: conn,
+            line_ids: Vec::new(),
+        })
+
+    }
+
+    pub fn process_file_content(&mut self, content: &str) -> Result<Vec<i64>> {
+        let tx = self.db_connection.transaction()?;
+        let current_time_str = Utc::now().to_rfc3339();
+
+        // Get all currently active lines for this file
+        let old_active_lines_by_order: HashMap<i64, TrackedLine>;
+        let old_active_hashes_to_ids: HashMap<String, Vec<i64>>;
+        let old_active_ids: HashSet<i64>;
+
+        {
+            let mut stmt = tx.prepare(
+                "SELECT id, current_content, content_hash, is_active, last_known_line_number 
+                 FROM lines WHERE file_path = ? AND is_active = 1 
+                 ORDER BY last_known_line_number ASC"
+            )?;
+            let active_lines_iter = stmt.query_map(params![&self.file_path], |row| {
+                let line = TrackedLine {
+                    id: row.get(0)?,
+                    content: row.get(1)?,
+                    hash: row.get(2)?,
+                    is_active: row.get(3)?,
+                    last_known_line_number: row.get(4)?,
+                };
+                Ok(line)
+            })?;
+
+            let mut temp_lines_by_order = HashMap::new();
+            let mut temp_hashes_to_ids: HashMap<_, Vec<i64>> = HashMap::new();
+            let mut temp_ids = HashSet::new();
+
+            for line_result in active_lines_iter {
+                let line = line_result?;
+                if let Some(order) = line.last_known_line_number {
+                    temp_lines_by_order.insert(order, line.clone());
+                }
+                temp_hashes_to_ids.entry(line.hash.clone()).or_default().push(line.id);
+                temp_ids.insert(line.id);
+            }
+            old_active_lines_by_order = temp_lines_by_order;
+            old_active_hashes_to_ids = temp_hashes_to_ids;
+            old_active_ids = temp_ids;
+        }
+
+        // Process the current file content line by line
+        let mut matched_current_run_ids: HashSet<i64> = HashSet::new();
+        let mut result_line_ids: Vec<i64> = Vec::new();
+
+        {
+            let mut insert_stmt = tx.prepare_cached(
+                "INSERT INTO lines (file_path, current_content, content_hash, is_active, last_known_line_number, created_at, updated_at)
+                 VALUES (?, ?, ?, 1, ?, ?, ?)"
+            )?;
+            let mut update_stmt = tx.prepare_cached(
+                "UPDATE lines SET current_content = ?, is_active = 1, last_known_line_number = ?, updated_at = ? WHERE id = ?"
+            )?;
+
+            for (line_num_0_idx, line) in content.lines().enumerate() {
+                let current_line_num = (line_num_0_idx + 1) as i64;
+                let trimmed_content = line.trim();
+                let content_hash = generate_content_hash(trimmed_content);
+
+                let mut found_match = false;
+                let mut line_id: i64 = 0;
+
+                // Check if content is at the same position with same hash
+                if let Some(old_line_at_pos) = old_active_lines_by_order.get(&current_line_num) {
+                    if old_line_at_pos.hash == content_hash {
+                        update_stmt.execute(
+                            params![trimmed_content, current_line_num, current_time_str, old_line_at_pos.id]
+                        )?;
+                        matched_current_run_ids.insert(old_line_at_pos.id);
+                        line_id = old_line_at_pos.id;
+                        found_match = true;
+                    }
+                }
+
+                // If not matched at current position, check if this content exists elsewhere
+                if !found_match {
+                    let mut matched_id_for_reuse: Option<i64> = None;
+                    if let Some(ids_for_hash) = old_active_hashes_to_ids.get(&content_hash) {
+                        for &id in ids_for_hash {
+                            if old_active_ids.contains(&id) && !matched_current_run_ids.contains(&id) {
+                                matched_id_for_reuse = Some(id);
+                                break;
+                            }
+                        }
+                    }
+
+                    if let Some(id_to_reuse) = matched_id_for_reuse {
+                        update_stmt.execute(
+                            params![trimmed_content, current_line_num, current_time_str, id_to_reuse]
+                        )?;
+                        matched_current_run_ids.insert(id_to_reuse);
+                        line_id = id_to_reuse;
+                    } else {
+                        insert_stmt.execute(
+                            params![&self.file_path, trimmed_content, content_hash, current_line_num, current_time_str, current_time_str]
+                        )?;
+                        let new_id = tx.last_insert_rowid();
+                        matched_current_run_ids.insert(new_id);
+                        line_id = new_id;
+                    }
+                }
+
+                result_line_ids.push(line_id);
+            }
+
+            // Deactivate lines that are no longer in the file
+            let mut deactivate_stmt = tx.prepare_cached(
+                "UPDATE lines SET is_active = 0, updated_at = ? WHERE id = ?"
+            )?;
+
+            for &old_id in &old_active_ids {
+                if !matched_current_run_ids.contains(&old_id) {
+                    deactivate_stmt.execute(params![current_time_str, old_id])?;
+                }
+            }
+        }
+
+        tx.commit()?;
+        self.line_ids = result_line_ids.clone();
+        Ok(result_line_ids)
+    }
+
+    pub fn get_line_id(&self, line_number: usize) -> Option<i64> {
+        if line_number == 0 || line_number > self.line_ids.len() {
+            None
+        } else {
+            Some(self.line_ids[line_number - 1])
+        }
+    }
+}
+
+// impl Drop for LineTracker {
+//     fn drop(&mut self) {
+//         self.db_connection.close();
+//     }
+// }
+
+fn generate_content_hash(content: &str) -> String {
+    let normalized_line = content.trim();
+    let mut hasher = Sha256::new();
+    hasher.update(normalized_line.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_line_tracking_basic() -> Result<()> {
+        let test_content = "Line 1\nLine 2\nLine 3\n";
+        let mut tracker = LineTracker::new_in_memory("test_file.txt")?;
+        
+        let ids = tracker.process_file_content(test_content)?;
+        assert_eq!(ids.len(), 3);
+        
+        assert_eq!(tracker.get_line_id(1), Some(ids[0]));
+        assert_eq!(tracker.get_line_id(2), Some(ids[1]));
+        assert_eq!(tracker.get_line_id(3), Some(ids[2]));
+        assert_eq!(tracker.get_line_id(4), None);
+        
+        Ok(())
+    }
+
+    #[test]
+    fn test_line_tracking_reuse() -> Result<()> {
+        let mut tracker = LineTracker::new_in_memory("test_file2.txt")?;
+        
+        // First version
+        let content1 = "Hello\nWorld\n";
+        let ids1 = tracker.process_file_content(content1)?;
+        
+        // Second version - reorder lines
+        let content2 = "World\nHello\n";
+        let ids2 = tracker.process_file_content(content2)?;
+        
+        // IDs should be reused but in different order
+        assert_eq!(ids2[0], ids1[1]); // "World" keeps same ID
+        assert_eq!(ids2[1], ids1[0]); // "Hello" keeps same ID
+        
+        Ok(())
+    }
+}

--- a/src/line_tracker.rs
+++ b/src/line_tracker.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;
-use std::time::Instant;
+//use std::time::Instant;
 
 pub struct LineTracker {
     content_to_id: HashMap<u64, Vec<i64>>,
@@ -42,7 +42,7 @@ impl LineTracker {
         let mut used_ids: HashSet<i64> = HashSet::new();
         let mut result_ids = Vec::with_capacity(lines.len());
 
-        let start = Instant::now();
+        //let start = Instant::now();
         // Assign IDs with simple in-memory logic
         for (idx, &hash) in line_hashes.iter().enumerate() {
             let line_num = idx + 1;
@@ -74,7 +74,7 @@ impl LineTracker {
             new_position_to_id.insert(line_num, id);
             result_ids.push(id);
         }
-        println!("-- b: {} ms", start.elapsed().as_millis());
+        //println!("-- b: {} ms", start.elapsed().as_millis());
 
         // Update internal state
         self.content_to_id = new_content_to_id;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -442,7 +442,7 @@ fn find_parent_line(parent: AstNode, depth: usize) -> Option<AstNode> {
             AstNodeKind::Line { .. } => Some(e.clone()),
             _ => None,
         })
-        .last()?;
+        .next_back()?;
     find_parent_line(last_child_line, depth - 1)
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -719,9 +719,12 @@ fn apply_line_ids_to_ast(node: &AstNode, line_tracker: &LineTracker, _text: &str
         // Get the line number from the location and assign stable_id
         let row = node.0.location.row;
         if let Some(line_id) = line_tracker.get_line_id(row + 1) {
-            // We need to access the internal mutable state to set stable_id
-            // This is tricky due to Arc wrapping, but we can modify the approach
-            set_node_stable_id(node, line_id);
+            // negative id corresponds to special cases such as empty lines
+            if line_id > 0 {
+                // We need to access the internal mutable state to set stable_id
+                // This is tricky due to Arc wrapping, but we can modify the approach
+                set_node_stable_id(node, line_id);
+            }
         }
     }
     
@@ -1712,7 +1715,7 @@ mod tests {
 
     #[test]
     fn test_parse_mails() -> Result<(), Box<dyn std::error::Error>> {
-        for (input, g_mail, g_title) in vec![
+        for (input, g_mail, g_title) in [
             ("[mailto:hoge@example.com example email]", "mailto:hoge@example.com", Some("example email".to_string())),
         ]{
                 println!("parsing {input}");

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::ops;
 use std::cmp::Ordering;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+//use std::time::{Instant};
 use thiserror::Error;
 use log;
 
@@ -694,11 +694,11 @@ pub fn parse_text(text: &str) -> ParserResult {
 
 pub fn parse_text_with_persistent_line_tracking(text: &str, line_tracker: &mut LineTracker) -> ParserResult {
     // First, run regular parsing
-    let start = Instant::now();
+    //let start = Instant::now();
     let result = parse_text(text);
-    println!("-- {} ms for parsing", start.elapsed().as_millis());
+    //println!("-- {} ms for parsing", start.elapsed().as_millis());
 
-    let start = Instant::now();
+    //let start = Instant::now();
     let _line_ids = match line_tracker.process_file_content(text) {
         Ok(ids) => ids,
         Err(_) => {
@@ -706,7 +706,7 @@ pub fn parse_text_with_persistent_line_tracking(text: &str, line_tracker: &mut L
             return result;
         }
     };
-    println!("-- {} ms for processing file", start.elapsed().as_millis());
+    //println!("-- {} ms for processing file", start.elapsed().as_millis());
 
     // Apply line IDs to Line and relevant nodes in the AST
     apply_line_ids_to_ast(&result.ast, line_tracker, text);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -692,22 +692,11 @@ pub fn parse_text(text: &str) -> ParserResult {
     ParserResult{ast: root, parse_errors: errors}
 }
 
-pub fn parse_text_with_line_tracking(text: &str, file_path: &str) -> ParserResult {
+pub fn parse_text_with_persistent_line_tracking(text: &str, line_tracker: &mut LineTracker) -> ParserResult {
     // First, run regular parsing
     let start = Instant::now();
     let result = parse_text(text);
     println!("-- {} ms for parsing", start.elapsed().as_millis());
-    
-    let start = Instant::now();
-    // Then try to apply line tracking
-    let mut line_tracker = match LineTracker::new(file_path) {
-        Ok(tracker) => tracker,
-        Err(_) => {
-            // Return regular parsing result if line tracker fails
-            return result;
-        }
-    };
-    println!("-- {} ms for db connection", start.elapsed().as_millis());
 
     let start = Instant::now();
     let _line_ids = match line_tracker.process_file_content(text) {
@@ -720,7 +709,7 @@ pub fn parse_text_with_line_tracking(text: &str, file_path: &str) -> ParserResul
     println!("-- {} ms for processing file", start.elapsed().as_millis());
 
     // Apply line IDs to Line and relevant nodes in the AST
-    apply_line_ids_to_ast(&result.ast, &line_tracker, text);
+    apply_line_ids_to_ast(&result.ast, line_tracker, text);
     
     result
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,11 +6,13 @@ use std::fmt;
 use std::ops;
 use std::cmp::Ordering;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use thiserror::Error;
 use log;
 
 use pest;
 use pest::iterators::Pair;
+use crate::line_tracker::LineTracker;
 
 //use serde::{Deserialize, Serialize};
 
@@ -122,6 +124,7 @@ pub struct AstNodeInternal {
     pub contents: Mutex<Vec<AstNode>>,
     pub children: Mutex<Vec<AstNode>>,
     pub kind: AstNodeKind,
+    pub stable_id: Mutex<Option<i64>>,
     // text will be the string matched with this AstNode.
     // will be used when contents.len() == 0
     // pub text: &'a str,
@@ -258,12 +261,25 @@ impl AstNode {
                 contents: Mutex::new(vec![]),
                 children: Mutex::new(vec![]),
                 kind: kind.unwrap_or(AstNodeKind::Dummy),
+                stable_id: Mutex::new(None),
             },
             location: Location {
                 row,
                 input: Arc::from(input),
                 span: span.unwrap_or(Span(0, input.len())),
             },
+        }))
+    }
+
+    pub fn with_line_id(_input: &str, location: Location, kind: Option<AstNodeKind>, line_id: Option<i64>) -> Self {
+        AstNode(Arc::new(AstNodeImpl {
+            value: AstNodeInternal {
+                contents: Mutex::new(vec![]),
+                children: Mutex::new(vec![]),
+                kind: kind.unwrap_or(AstNodeKind::Dummy),
+                stable_id: Mutex::new(line_id),
+            },
+            location,
         }))
     }
     pub fn line(
@@ -676,6 +692,60 @@ pub fn parse_text(text: &str) -> ParserResult {
     ParserResult{ast: root, parse_errors: errors}
 }
 
+pub fn parse_text_with_line_tracking(text: &str, file_path: &str) -> ParserResult {
+    // First, run regular parsing
+    let start = Instant::now();
+    let result = parse_text(text);
+    println!("-- {} ms for parsing", start.elapsed().as_millis());
+    
+    let start = Instant::now();
+    // Then try to apply line tracking
+    let mut line_tracker = match LineTracker::new(file_path) {
+        Ok(tracker) => tracker,
+        Err(_) => {
+            // Return regular parsing result if line tracker fails
+            return result;
+        }
+    };
+    println!("-- {} ms for db connection", start.elapsed().as_millis());
+
+    let start = Instant::now();
+    let _line_ids = match line_tracker.process_file_content(text) {
+        Ok(ids) => ids,
+        Err(_) => {
+            // Return regular parsing result if line tracking fails
+            return result;
+        }
+    };
+    println!("-- {} ms for processing file", start.elapsed().as_millis());
+
+    // Apply line IDs to Line and relevant nodes in the AST
+    apply_line_ids_to_ast(&result.ast, &line_tracker, text);
+    
+    result
+}
+
+fn apply_line_ids_to_ast(node: &AstNode, line_tracker: &LineTracker, _text: &str) {
+    if let AstNodeKind::Line { .. } = node.kind() {
+        // Get the line number from the location and assign stable_id
+        let row = node.0.location.row;
+        if let Some(line_id) = line_tracker.get_line_id(row + 1) {
+            // We need to access the internal mutable state to set stable_id
+            // This is tricky due to Arc wrapping, but we can modify the approach
+            set_node_stable_id(node, line_id);
+        }
+    }
+    
+    // Recursively apply to children
+    let children = node.value().children.lock().unwrap();
+    for child in children.iter() {
+        apply_line_ids_to_ast(child, line_tracker, _text);
+    }
+}
+
+fn set_node_stable_id(node: &AstNode, stable_id: i64) {
+    *node.value().stable_id.lock().unwrap() = Some(stable_id);
+}
 
 fn parse_command_line(
     line: &str,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -35,7 +35,11 @@ impl Renderer for HtmlRenderer {
 impl HtmlRenderer {
     fn get_stable_id_attr(&self, ast: &AstNode) -> String {
         if let Some(stable_id) = *ast.value().stable_id.lock().unwrap() {
-            format!(" data-line-id=\"{}\"", stable_id)
+            if stable_id > 0 {
+                format!(" data-line-id=\"{}\"", stable_id)
+            } else {
+                String::new()
+            }
         } else {
             String::new()
         }
@@ -48,7 +52,7 @@ impl HtmlRenderer {
                 let children = ast.value().children.lock().unwrap();
                 for child in children.iter() {
                     let id_attr = self.get_stable_id_attr(child);
-                    write!(output, "<li class=\"patto-line\" style=\"list-style-type: none; min-height: 1em;\"{}>\n", id_attr)?;
+                    write!(output, "<li class=\"patto-line\" style=\"list-style-type: none; min-height: 1em;\"{}>", id_attr)?;
                     self._format_impl(&child, output)?;
                     write!(output, "</li>")?;
                 }
@@ -103,7 +107,7 @@ impl HtmlRenderer {
                     write!(output, "<ul style=\"margin-bottom: 0.5rem\">")?;
                     for child in children.iter() {
                         let id_attr = self.get_stable_id_attr(child);
-                        write!(output, "<li class=\"patto-item\" style=\"min-height: 1em;\"{}>\n", id_attr)?;
+                        write!(output, "<li class=\"patto-item\" style=\"min-height: 1em;\"{}>", id_attr)?;
                         self._format_impl(&child, output)?;
                         write!(output, "</li>")?;
                     }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -35,11 +35,7 @@ impl Renderer for HtmlRenderer {
 impl HtmlRenderer {
     fn get_stable_id_attr(&self, ast: &AstNode) -> String {
         if let Some(stable_id) = *ast.value().stable_id.lock().unwrap() {
-            if stable_id > 0 {
-                format!(" data-line-id=\"{}\"", stable_id)
-            } else {
-                String::new()
-            }
+            format!(" data-line-id=\"{}\"", stable_id)
         } else {
             String::new()
         }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -33,6 +33,13 @@ impl Renderer for HtmlRenderer {
 }
 
 impl HtmlRenderer {
+    fn get_stable_id_attr(&self, ast: &AstNode) -> String {
+        if let Some(stable_id) = *ast.value().stable_id.lock().unwrap() {
+            format!(" data-line-id=\"{}\"", stable_id)
+        } else {
+            String::new()
+        }
+    }
 
     fn _format_impl(&self, ast: &AstNode, output: &mut dyn Write) -> io::Result<()> {
         match &ast.kind() {
@@ -40,7 +47,8 @@ impl HtmlRenderer {
                 write!(output, "<ul style=\"margin-bottom: 1.5rem\">")?;
                 let children = ast.value().children.lock().unwrap();
                 for child in children.iter() {
-                    write!(output, "<li class=\"patto-line\" style=\"list-style-type: none; min-height: 1em;\">")?;
+                    let id_attr = self.get_stable_id_attr(child);
+                    write!(output, "<li class=\"patto-line\" style=\"list-style-type: none; min-height: 1em;\"{}>\n", id_attr)?;
                     self._format_impl(&child, output)?;
                     write!(output, "</li>")?;
                 }
@@ -94,7 +102,8 @@ impl HtmlRenderer {
                 if !children.is_empty() {
                     write!(output, "<ul style=\"margin-bottom: 0.5rem\">")?;
                     for child in children.iter() {
-                        write!(output, "<li class=\"patto-item\" style=\"min-height: 1em;\">")?;
+                        let id_attr = self.get_stable_id_attr(child);
+                        write!(output, "<li class=\"patto-item\" style=\"min-height: 1em;\"{}>\n", id_attr)?;
                         self._format_impl(&child, output)?;
                         write!(output, "</li>")?;
                     }


### PR DESCRIPTION
since the algorithm is too naive, re-rendering still occurs when some lines are duplicated (i.e. the lines with the same content are add/removed).