### PR TITLE
feat: add recency grouping to tasks_review and new timeframe presets

### DIFF
--- a/lua/patto.lua
+++ b/lua/patto.lua
@@ -203,13 +203,14 @@ return {
     })
 
     -- Review completed tasks by timeframe
-    -- Usage: :LspPattoTasksReview [today|this_week|YYYY-MM-DD:YYYY-MM-DD]
-    -- No arg = today, "this_week" = current week Mon–today, "YYYY-MM-DD:YYYY-MM-DD" = custom range
+    -- Usage: :LspPattoTasksReview [today|yesterday|this_week|last_week|this_month|YYYY-MM-DD:YYYY-MM-DD]
+    -- No arg = today
     vim.api.nvim_buf_create_user_command(bufnr, 'LspPattoTasksReview', function(opts)
       local arg = opts.args ~= '' and opts.args or 'today'
       local arguments = {}
 
-      if arg == 'today' or arg == 'this_week' then
+      local named = { today = true, yesterday = true, this_week = true, last_week = true, this_month = true }
+      if named[arg] then
         arguments = {arg}
       else
         -- Try to parse as "YYYY-MM-DD:YYYY-MM-DD"
@@ -217,7 +218,7 @@ return {
         if from and to then
           arguments = {'custom', from, to}
         else
-          vim.notify('LspPattoTasksReview: invalid argument "' .. arg .. '". Use today|this_week|YYYY-MM-DD:YYYY-MM-DD', vim.log.levels.ERROR)
+          vim.notify('LspPattoTasksReview: invalid argument "' .. arg .. '". Use today|yesterday|this_week|last_week|this_month|YYYY-MM-DD:YYYY-MM-DD', vim.log.levels.ERROR)
           return
         end
       end
@@ -248,10 +249,10 @@ return {
         vim.cmd('setlocal nowrap')
       end)
     end, {
-      desc = 'Review completed tasks (today|this_week|YYYY-MM-DD:YYYY-MM-DD)',
+      desc = 'Review completed tasks (today|yesterday|this_week|last_week|this_month|YYYY-MM-DD:YYYY-MM-DD)',
       nargs = '?',
       complete = function()
-        return {'today', 'this_week'}
+        return {'today', 'yesterday', 'this_week', 'last_week', 'this_month'}
       end,
     })
 

--- a/lua/trouble/sources/patto_tasks_review.lua
+++ b/lua/trouble/sources/patto_tasks_review.lua
@@ -4,23 +4,76 @@ local Item = require("trouble.item")
 ---@type trouble.Source
 local M = {}
 
+--- Classify a "YYYY-MM-DD" completed_at string into a display bucket.
+--- Buckets (most recent first): Today, Yesterday, This Week, Last Week, This Month, Older
+--- Returns: bucket label (string), sort key (number, lower = more recent)
+local function classify_date(date_str)
+  if not date_str or date_str == "" then
+    return "Older", 1
+  end
+  local y, mo, d = string.match(date_str, "^(%d%d%d%d)%-(%d%d)%-(%d%d)$")
+  if not y then
+    return "Older", 1
+  end
+
+  local completed_ts = os.time({ year = tonumber(y), month = tonumber(mo), day = tonumber(d), hour = 12, min = 0, sec = 0 })
+
+  local now = os.time()
+  local t = os.date("*t", now) --[[@as table]]
+  local today_start  = os.time({ year = t.year, month = t.month, day = t.day,     hour = 0, min = 0, sec = 0 })
+  local today_end    = today_start + 86400 - 1
+  local yest_start   = today_start - 86400
+  local yest_end     = today_start - 1
+
+  -- Monday of this week
+  local days_since_mon = (t.wday - 2) % 7  -- wday: 1=Sun, 2=Mon
+  local this_week_start = today_start - days_since_mon * 86400
+  local last_week_start = this_week_start - 7 * 86400
+  local last_week_end   = this_week_start - 1
+
+  -- First day of this month
+  local month_start = os.time({ year = t.year, month = t.month, day = 1, hour = 0, min = 0, sec = 0 })
+
+  if completed_ts >= today_start and completed_ts <= today_end then
+    return "📅 Today", 6
+  elseif completed_ts >= yest_start and completed_ts <= yest_end then
+    return "📅 Yesterday", 5
+  elseif completed_ts >= this_week_start then
+    return "📅 This Week", 4
+  elseif completed_ts >= last_week_start and completed_ts <= last_week_end then
+    return "📅 Last Week", 3
+  elseif completed_ts >= month_start then
+    return "📅 This Month", 2
+  else
+    return "📅 Older", 1
+  end
+end
+
 ---@diagnostic disable-next-line: missing-fields
 M.config = {
-  -- timeframe can be overridden when opening: trouble.open({ mode = "patto_tasks_review", timeframe = "this_week" })
-  timeframe = "today",
   formatters = {
     completed_at = function(ctx)
-      local task = ctx.item.item or {}
       return {
-        text = task.completed_at or "",
+        text = (ctx.item.item or {}).completed_at or "",
         hl = "Comment",
       }
     end,
     completed_date_group = function(ctx)
-      local task = ctx.item.item or {}
       return {
-        text = task.completed_at or "Unknown",
+        text = ctx.item.completed_date_group or "Older",
       }
+    end,
+  },
+  sorters = {
+    completed_at = function(item)
+      local date_str = (item.item or {}).completed_at
+      if not date_str or date_str == "" then return 0 end
+      local y, mo, d = string.match(date_str, "^(%d%d%d%d)%-(%d%d)%-(%d%d)$")
+      if not y then return 0 end
+      return os.time({ year = tonumber(y), month = tonumber(mo), day = tonumber(d), hour = 12, min = 0, sec = 0 })
+    end,
+    completed_date_group_order = function(item)
+      return item.completed_date_group_order or 1
     end,
   },
   modes = {
@@ -28,11 +81,11 @@ M.config = {
       mode = "patto_tasks_review",
       events = { "BufWritePost" },
       source = "patto_tasks_review",
-      desc = "Completed tasks grouped by date",
+      desc = "Completed tasks grouped by recency (today/yesterday/this week/last week/this month)",
       groups = {
-        { "completed_date_group", format = "📅 {completed_date_group}" },
+        { "completed_date_group", format = "{completed_date_group}" },
       },
-      sort = { "completed_date_group", "filename", "pos" },
+      sort = { "completed_date_group_order", "completed_at", "filename", "pos" },
       format = "{completed_at} {text} {filename}",
       win = {
         position = "bottom",
@@ -43,8 +96,11 @@ M.config = {
 }
 
 --- Fetch completed tasks from Patto LSP server
+--- Computes "recent" range client-side (start of last week or month, whichever earlier, through today)
+--- and sends as custom date range to the backend.
 --- @param cb function Callback to receive items
-function M.get(cb)
+--- @param ctx table Trouble source context
+function M.get(cb, ctx)
   local patto_bufnr = nil
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     if vim.api.nvim_buf_is_loaded(bufnr) and vim.bo[bufnr].filetype == "patto" then
@@ -58,24 +114,19 @@ function M.get(cb)
     return
   end
 
-  -- Read timeframe from config (can be set at open time)
-  local timeframe = M.config.timeframe or "today"
-  local arguments = {}
-  if timeframe == "today" or timeframe == "this_week" then
-    arguments = { timeframe }
-  else
-    -- Expect "YYYY-MM-DD:YYYY-MM-DD"
-    local from, to = string.match(tostring(timeframe), "^(%d%d%d%d%-%d%d%-%d%d):(%d%d%d%d%-%d%d%-%d%d)$")
-    if from and to then
-      arguments = { "custom", from, to }
-    else
-      arguments = { "today" }
-    end
-  end
+  -- Compute "recent" range: from (start of last week OR start of this month, whichever earlier) through today
+  local now = os.time()
+  local t = os.date("*t", now) --[[@as table]]
+  local today_str = os.date("%Y-%m-%d", now)
+  local days_since_mon = (t.wday - 2) % 7  -- wday: 1=Sun, 2=Mon
+  local last_week_start_ts = now - (days_since_mon + 7) * 86400
+  local month_start_ts = os.time({ year = t.year, month = t.month, day = 1, hour = 0, min = 0, sec = 0 })
+  local from_ts = math.min(last_week_start_ts, month_start_ts)
+  local from_str = os.date("%Y-%m-%d", from_ts)
 
   vim.lsp.buf_request_all(patto_bufnr, "workspace/executeCommand", {
     command = "experimental/tasks_review",
-    arguments = arguments,
+    arguments = { "custom", from_str, today_str },
   }, function(results, _ctx, _config)
     local items = {} ---@type trouble.Item[]
 
@@ -92,15 +143,18 @@ function M.get(cb)
       for _, task in ipairs(vres.result) do
         local row = task.location.range.start.line + 1
         local col = task.location.range.start.character + 1
+        local bucket, order = classify_date(task.completed_at)
 
         items[#items + 1] = Item.new({
-          buf      = vim.fn.bufadd(vim.uri_to_fname(task.location.uri)),
-          pos      = { row, col },
-          end_pos  = { row, col },
-          text     = task.text,
-          filename = vim.uri_to_fname(task.location.uri),
-          item     = task,
-          source   = "patto_tasks_review",
+          buf                       = vim.fn.bufadd(vim.uri_to_fname(task.location.uri)),
+          pos                       = { row, col },
+          end_pos                   = { row, col },
+          text                      = task.text,
+          filename                  = vim.uri_to_fname(task.location.uri),
+          item                      = task,
+          source                    = "patto_tasks_review",
+          completed_date_group      = bucket,
+          completed_date_group_order = order,
         })
       end
       ::continue::

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -1158,10 +1158,27 @@ impl LanguageServer for Backend {
 
                 let (from, to) = match timeframe {
                     "today" => (Some(today), Some(today)),
+                    "yesterday" => {
+                        let yesterday = today - chrono::Duration::days(1);
+                        (Some(yesterday), Some(yesterday))
+                    }
                     "this_week" => {
                         use chrono::Datelike;
                         let weekday = today.weekday().num_days_from_monday(); // Mon=0
                         let start = today - chrono::Duration::days(weekday as i64);
+                        (Some(start), Some(today))
+                    }
+                    "last_week" => {
+                        use chrono::Datelike;
+                        let weekday = today.weekday().num_days_from_monday(); // Mon=0
+                        let this_week_start = today - chrono::Duration::days(weekday as i64);
+                        let last_week_start = this_week_start - chrono::Duration::days(7);
+                        let last_week_end = this_week_start - chrono::Duration::days(1);
+                        (Some(last_week_start), Some(last_week_end))
+                    }
+                    "this_month" => {
+                        use chrono::Datelike;
+                        let start = today.with_day(1).unwrap_or(today);
                         (Some(start), Some(today))
                     }
                     "custom" => {


### PR DESCRIPTION
## Summary

- **`:Trouble patto_tasks_review`** no longer requires a timeframe parameter. It now fetches a \"recent\" date range (start of last week or start of this month, whichever is earlier, through today) computed in Lua and sent as a `custom` range to the backend. Items are grouped client-side into recency buckets ordered oldest → newest: **Older → This Month → Last Week → This Week → Yesterday → Today**
- **New timeframe presets** added to the LSP backend (`yesterday`, `last_week`, `this_month`) for use with `:LspPattoTasksReview`
- **`:LspPattoTasksReview`** tab completion updated to return `today`, `yesterday`, `this_week`, `last_week`, `this_month`

## Changes

- `src/lsp/backend.rs` — add `yesterday`, `last_week`, `this_month` match arms to `experimental/tasks_review`
- `lua/trouble/sources/patto_tasks_review.lua` — rewrite to use recency bucket grouping with custom sorters; no params required
- `lua/patto.lua` — extend `:LspPattoTasksReview` completion and argument handling with new presets