### PR TITLE
Auto-resize trouble window to fit item count

### DIFF
--- a/lua/trouble/sources/patto_tasks.lua
+++ b/lua/trouble/sources/patto_tasks.lua
@@ -191,6 +191,26 @@ function M.get(cb)
     end
     
     cb(items)
+
+    -- Auto-resize the trouble window to fit item count
+    vim.schedule(function()
+      local unique_groups = {}
+      for _, item in ipairs(items) do
+        unique_groups[item.deadline_group] = true
+      end
+      local group_count = 0
+      for _ in pairs(unique_groups) do group_count = group_count + 1 end
+      local target = math.max(#items + group_count, 1)
+      local max_size = math.floor(vim.o.lines * 0.35)
+      target = math.min(target, max_size)
+      for _, win in ipairs(vim.api.nvim_list_wins()) do
+        local buf = vim.api.nvim_win_get_buf(win)
+        if vim.bo[buf].filetype == "trouble" then
+          vim.api.nvim_win_set_height(win, target)
+          break
+        end
+      end
+    end)
   end)
 end
 

--- a/lua/trouble/sources/patto_tasks_review.lua
+++ b/lua/trouble/sources/patto_tasks_review.lua
@@ -161,6 +161,26 @@ function M.get(cb, ctx)
     end
 
     cb(items)
+
+    -- Auto-resize the trouble window to fit item count
+    vim.schedule(function()
+      local unique_groups = {}
+      for _, item in ipairs(items) do
+        unique_groups[item.completed_date_group] = true
+      end
+      local group_count = 0
+      for _ in pairs(unique_groups) do group_count = group_count + 1 end
+      local target = math.max(#items + group_count, 1)
+      local max_size = math.floor(vim.o.lines * 0.35)
+      target = math.min(target, max_size)
+      for _, win in ipairs(vim.api.nvim_list_wins()) do
+        local buf = vim.api.nvim_win_get_buf(win)
+        if vim.bo[buf].filetype == "trouble" then
+          vim.api.nvim_win_set_height(win, target)
+          break
+        end
+      end
+    end)
   end)
 end
 


### PR DESCRIPTION
## Summary

- After each item fetch, resize the Trouble window height to `#items + #unique_groups` so the window shrinks to fit when fewer items are present
- Caps at 35% of editor height (existing `size = 0.35` max)
- Minimum height of 1 line
- Applies dynamically on every refresh (BufWritePost, InsertLeave, BufEnter) in both `patto_tasks` and `patto_tasks_review` sources