### PR TITLE
fix: preserve inline code in markdown table cells

### DIFF
--- a/src/importer/converter.rs
+++ b/src/importer/converter.rs
@@ -565,6 +565,10 @@ impl MarkdownImporter {
 
                     if in_heading {
                         heading_contents.push(inline_code);
+                    } else if in_table {
+                        if let Some(cell) = current_cell.as_ref() {
+                            cell.add_content(inline_code);
+                        }
                     } else {
                         pending_contents.push(inline_code);
                     }

--- a/tests/markdown_import.rs
+++ b/tests/markdown_import.rs
@@ -617,3 +617,21 @@ fn test_import_task_with_dataview_scheduled_and_completed() {
         patto
     );
 }
+
+#[test]
+fn test_table_inline_code_in_cells() {
+    let md = "| Header | Code |\n|--------|------|\n| plain  | `foo` |\n";
+    let patto = import_lossy(md);
+    assert!(
+        patto.contains("foo"),
+        "inline code in table cell should be preserved: {}",
+        patto
+    );
+    // The backtick content should appear as a code node, not be silently dropped
+    // In patto rendering a code node serializes with the code text present
+    assert!(
+        patto.contains("foo"),
+        "inline code text 'foo' must appear in output: {}",
+        patto
+    );
+}


### PR DESCRIPTION
## Summary

- `Event::Code` (backtick inline code) was always pushed to `pending_contents`, bypassing the `in_table` branch that routes content to the current cell `AstNode`
- As a result, `` `text` `` inside a markdown table cell was silently dropped during import
- Added `else if in_table` check in `src/importer/converter.rs` so inline code is attached directly to the cell node
- Added regression test `test_table_inline_code_in_cells` in `tests/markdown_import.rs`