### PR TITLE
feat: task time tracking with clock-in/out and structured display

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -122,6 +122,33 @@ function stopPreviewServer() {
 	previewPort = null;
 }
 
+/** Build a rich display label for a task from its structured fields. */
+function taskLabel(task: any): string {
+	const parts: string[] = [task.text as string];
+
+	// due date chip
+	const due = task.due;
+	if (due && typeof due === 'object') {
+		const dueStr: string = due.Date ?? (due.DateTime ? (due.DateTime as string).slice(0, 10) : '');
+		if (dueStr) parts.push(`[due:${dueStr}]`);
+	}
+
+	// status chip (only show non-todo)
+	if (task.status === 'Doing') parts.push('[doing]');
+
+	// time_spent chip
+	const ts = task.time_spent;
+	if (ts && typeof ts === 'object') {
+		const h: number = ts.hours ?? 0;
+		const m: number = ts.minutes ?? 0;
+		if (h > 0 && m > 0) parts.push(`[${h}h${m}m]`);
+		else if (h > 0)     parts.push(`[${h}h]`);
+		else if (m > 0)     parts.push(`[${m}m]`);
+	}
+
+	return parts.join(' ');
+}
+
 export class TasksProvider implements vscode.TreeDataProvider<Task> {
 	private tasks: Task[];
 	constructor() {
@@ -147,7 +174,7 @@ export class TasksProvider implements vscode.TreeDataProvider<Task> {
 		this.tasks = [];
 		for (let i = 0; i < result.length; ++i) {
 			this.tasks.push(new Task(
-				result[i]['text'],
+				taskLabel(result[i]),
 				result[i]['location'],
 				vscode.TreeItemCollapsibleState.None
 			));
@@ -485,8 +512,17 @@ function startLanguageClient(
 				for (const [date, tasks] of [...byDate.entries()].sort()) {
 					items.push({ label: `📅 ${date}`, kind: vscode.QuickPickItemKind.Separator });
 					for (const t of tasks) {
+						const ts = t.time_spent;
+						let timeChip = '';
+						if (ts && typeof ts === 'object') {
+							const h: number = ts.hours ?? 0;
+							const m: number = ts.minutes ?? 0;
+							if (h > 0 && m > 0) timeChip = ` ⏱ ${h}h${m}m`;
+							else if (h > 0)     timeChip = ` ⏱ ${h}h`;
+							else if (m > 0)     timeChip = ` ⏱ ${m}m`;
+						}
 						items.push({
-							label: `  ✓ ${t.text}`,
+							label: `  ✓ ${t.text}${timeChip}`,
 							description: Uri.parse(t.location.uri).fsPath.split('/').pop(),
 							detail: Uri.parse(t.location.uri).fsPath,
 						});
@@ -503,7 +539,7 @@ function startLanguageClient(
 					const doc = await vscode.workspace.openTextDocument(selected.detail);
 					const task = response.find((t: any) =>
 						Uri.parse(t.location.uri).fsPath === selected.detail &&
-						`  ✓ ${t.text}` === selected.label
+						selected.label.startsWith(`  ✓ ${t.text}`)
 					);
 					const line = task?.location?.range?.start?.line ?? 0;
 					const ed = await vscode.window.showTextDocument(doc);

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -522,7 +522,7 @@ function startLanguageClient(
 							else if (m > 0)     timeChip = ` ⏱ ${m}m`;
 						}
 						items.push({
-							label: `  ✓ ${t.text}${timeChip}`,
+							label: `  ✓ ${t.completed_at}  ${t.text}${timeChip}`,
 							description: Uri.parse(t.location.uri).fsPath.split('/').pop(),
 							detail: Uri.parse(t.location.uri).fsPath,
 						});
@@ -539,7 +539,7 @@ function startLanguageClient(
 					const doc = await vscode.workspace.openTextDocument(selected.detail);
 					const task = response.find((t: any) =>
 						Uri.parse(t.location.uri).fsPath === selected.detail &&
-						selected.label.startsWith(`  ✓ ${t.text}`)
+						selected.label.includes(t.text)
 					);
 					const line = task?.location?.range?.start?.line ?? 0;
 					const ed = await vscode.window.showTextDocument(doc);

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -124,14 +124,16 @@ function stopPreviewServer() {
 
 /** Build a rich display label for a task from its structured fields. */
 function taskLabel(task: any): string {
-	const parts: string[] = [task.text as string];
+	const parts: string[] = [];
 
-	// due date chip
+	// due date first
 	const due = task.due;
 	if (due && typeof due === 'object') {
 		const dueStr: string = due.Date ?? (due.DateTime ? (due.DateTime as string).slice(0, 10) : '');
 		if (dueStr) parts.push(`[due:${dueStr}]`);
 	}
+
+	parts.push(task.text as string);
 
 	// status chip (only show non-todo)
 	if (task.status === 'Doing') parts.push('[doing]');

--- a/lua/patto.lua
+++ b/lua/patto.lua
@@ -160,14 +160,15 @@ return {
             location_item.lnum = item.location.range.start.line + 1
             location_item.col = item.location.range.start.character + 1
 
-            -- Build a rich display string: label + structured chips
-            local parts = { item.text }
-            -- due date
+            -- Build a rich display string: due date + label + chips
+            local parts = {}
+            -- due date first
             local due = item.due
             if type(due) == "table" then
               local due_str = due.Date or (due.DateTime and string.match(due.DateTime, "^(%d%d%d%d%-%d%d%-%d%d)"))
               if due_str then parts[#parts+1] = "[due:" .. due_str .. "]" end
             end
+            parts[#parts+1] = item.text
             -- status (only show non-todo)
             if item.status == "Doing" then
               parts[#parts+1] = "[doing]"

--- a/lua/patto.lua
+++ b/lua/patto.lua
@@ -159,7 +159,32 @@ return {
             location_item.filename = vim.uri_to_fname(item.location.uri)
             location_item.lnum = item.location.range.start.line + 1
             location_item.col = item.location.range.start.character + 1
-            location_item.text = item.text
+
+            -- Build a rich display string: label + structured chips
+            local parts = { item.text }
+            -- due date
+            local due = item.due
+            if type(due) == "table" then
+              local due_str = due.Date or (due.DateTime and string.match(due.DateTime, "^(%d%d%d%d%-%d%d%-%d%d)"))
+              if due_str then parts[#parts+1] = "[due:" .. due_str .. "]" end
+            end
+            -- status (only show non-todo)
+            if item.status == "Doing" then
+              parts[#parts+1] = "[doing]"
+            end
+            -- time_spent
+            if type(item.time_spent) == "table" then
+              local h, m = item.time_spent.hours or 0, item.time_spent.minutes or 0
+              if h > 0 and m > 0 then
+                parts[#parts+1] = "[" .. h .. "h" .. m .. "m]"
+              elseif h > 0 then
+                parts[#parts+1] = "[" .. h .. "h]"
+              elseif m > 0 then
+                parts[#parts+1] = "[" .. m .. "m]"
+              end
+            end
+
+            location_item.text = table.concat(parts, " ")
             return location_item
           end, vres.result)
 
@@ -231,11 +256,26 @@ return {
         for _, vres in pairs(results) do
           if vres.result then
             for _, task in ipairs(vres.result) do
+              local parts = {}
+              if task.completed_at and task.completed_at ~= vim.NIL then
+                parts[#parts+1] = "[" .. task.completed_at .. "]"
+              end
+              parts[#parts+1] = task.text
+              if type(task.time_spent) == "table" then
+                local h, m = task.time_spent.hours or 0, task.time_spent.minutes or 0
+                if h > 0 and m > 0 then
+                  parts[#parts+1] = "[" .. h .. "h" .. m .. "m]"
+                elseif h > 0 then
+                  parts[#parts+1] = "[" .. h .. "h]"
+                elseif m > 0 then
+                  parts[#parts+1] = "[" .. m .. "m]"
+                end
+              end
               locs[#locs + 1] = {
                 filename = vim.uri_to_fname(task.location.uri),
                 lnum     = task.location.range.start.line + 1,
                 col      = task.location.range.start.character + 1,
-                text     = '[' .. task.completed_at .. '] ' .. task.text,
+                text     = table.concat(parts, " "),
               }
             end
           end

--- a/lua/trouble/sources/patto_tasks.lua
+++ b/lua/trouble/sources/patto_tasks.lua
@@ -132,7 +132,7 @@ M.config = {
       },
       sort   = { "deadline", "filename", "pos" },
       -- Format: status icon | label | due chip | time chips | file
-      format = "{task_status}{text}{task_due}{task_time_spent}{task_started_at} {filename}",
+      format = "{task_status}{task_due} {text}{task_time_spent}{task_started_at} {filename}",
       win = { position = "bottom", size = 0.25 },
     },
   },

--- a/lua/trouble/sources/patto_tasks.lua
+++ b/lua/trouble/sources/patto_tasks.lua
@@ -4,192 +4,183 @@ local Item = require("trouble.item")
 ---@type trouble.Source
 local M = {}
 
---- Parse deadline from task and return a category and sort key
---- @param task table The task from LSP
---- @return string category The deadline category (Overdue, Today, This Week, etc.)
---- @return number sort_key Numeric sort key for ordering
-local function parse_deadline(task)
-  if not task.due then
+-- ── helpers ──────────────────────────────────────────────────────────────────
+
+--- Extract a plain "YYYY-MM-DD" string from a Deadline enum value.
+local function deadline_date_str(d)
+  if not d then return nil end
+  if type(d) == "table" then
+    if d.Date     then return d.Date end
+    if d.DateTime then return string.match(d.DateTime, "^(%d%d%d%d%-%d%d%-%d%d)") end
+  end
+  return nil
+end
+
+--- Parse a "YYYY-MM-DD" string into an os.time timestamp (noon that day).
+local function date_ts(s)
+  if not s then return nil end
+  local y, mo, d = string.match(s, "^(%d%d%d%d)%-(%d%d)%-(%d%d)")
+  if not y then return nil end
+  return os.time({ year = tonumber(y), month = tonumber(mo), day = tonumber(d),
+                   hour = 12, min = 0, sec = 0 })
+end
+
+--- Classify a task's due date into a bucket label and numeric sort key.
+local function classify_due(task)
+  local due_str = deadline_date_str(task.due)
+  if not due_str then
     return "No Deadline", 9999999999
   end
-  
-  -- Extract date/time from Deadline enum variants
-  local year, month, day, hour, min, sec
-  if type(task.due) == "table" then
-    if task.due.Date then
-      year, month, day = string.match(task.due.Date, "^(%d+)%-(%d+)%-(%d+)")
-      hour, min, sec = 23, 59, 59  -- End of day for date-only deadlines
-    elseif task.due.DateTime then
-      -- Parse ISO 8601 format: YYYY-MM-DDTHH:MM:SS
-      year, month, day, hour, min, sec = string.match(task.due.DateTime, "^(%d+)%-(%d+)%-(%d+)T(%d+):(%d+):(%d+)")
-      if not hour then
-        -- Fallback: try without time component
-        year, month, day = string.match(task.due.DateTime, "^(%d+)%-(%d+)%-(%d+)")
-        hour, min, sec = 23, 59, 59
-      end
-    elseif task.due.Uninterpretable then
-      return "Uninterpretable", 9999999998
-    end
+
+  local due_ts = date_ts(due_str)
+  if not due_ts then
+    return "Invalid", 9999999998
   end
-  
-  if not year then
-    return "Invalid Deadline", 9999999997
-  end
-  
-  local due_time = os.time({year = tonumber(year), month = tonumber(month), day = tonumber(day), hour = tonumber(hour), min = tonumber(min), sec = tonumber(sec)})
-  local now = os.time()
-  local today = os.date("*t", now)
-  local today_start = os.time({year = today.year, month = today.month, day = today.day, hour = 0, min = 0, sec = 0})
-  local sort_key = due_time
-  
-  local diff_days = math.floor((due_time - today_start) / 86400)
-  
-  if diff_days < 0 then
-    return "⚠️  Overdue", sort_key
-  elseif diff_days == 0 then
-    return "📅 Today", sort_key
-  elseif diff_days == 1 then
-    return "📆 Tomorrow", sort_key
-  end
-  
-  -- Calculate end of current calendar week (Saturday 23:59:59)
-  -- wday: 1=Sunday, 2=Monday, ..., 7=Saturday
-  local days_until_saturday = 7 - today.wday
-  local week_end = os.time({year = today.year, month = today.month, day = today.day + days_until_saturday, hour = 23, min = 59, sec = 59})
-  
-  if due_time <= week_end then
-    return "📋 This Week", sort_key
-  end
-  
-  -- Calculate end of current calendar month
-  local next_month_year = today.year
-  local next_month = today.month + 1
-  if next_month > 12 then
-    next_month = 1
-    next_month_year = next_month_year + 1
-  end
-  -- First day of next month minus 1 second = last moment of current month
-  local month_end = os.time({year = next_month_year, month = next_month, day = 1, hour = 0, min = 0, sec = 0}) - 1
-  
-  if due_time <= month_end then
-    return "📌 This Month", sort_key
-  end
-  
-  return "📦 Later", sort_key
+
+  local now   = os.time()
+  local t     = os.date("*t", now) --[[@as table]]
+  local today_start = os.time({ year = t.year, month = t.month, day = t.day,
+                                 hour = 0, min = 0, sec = 0 })
+  local diff_days   = math.floor((due_ts - today_start) / 86400)
+
+  if diff_days < 0  then return "⚠Overdue",    due_ts end
+  if diff_days == 0 then return "Today",      due_ts end
+  if diff_days == 1 then return "Tomorrow",   due_ts end
+
+  local days_until_sat = 7 - t.wday   -- wday: 1=Sun … 7=Sat
+  local week_end = os.time({ year = t.year, month = t.month,
+                              day  = t.day + days_until_sat,
+                              hour = 23, min = 59, sec = 59 })
+  if due_ts <= week_end then return "  This Week", due_ts end
+
+  local nm_year, nm = t.year, t.month + 1
+  if nm > 12 then nm = 1; nm_year = nm_year + 1 end
+  local month_end = os.time({ year = nm_year, month = nm, day = 1,
+                               hour = 0, min = 0, sec = 0 }) - 1
+  if due_ts <= month_end then return "This Month", due_ts end
+
+  return "Later", due_ts
 end
+
+-- ── formatters ───────────────────────────────────────────────────────────────
 
 ---@diagnostic disable-next-line: missing-fields
 M.config = {
   formatters = {
+    -- Group header: bucket label
     deadline_group = function(ctx)
-      local category, _ = parse_deadline(ctx.item.item or {})
-      return {
-        text = category,
-      }
+      local label, _ = classify_due(ctx.item.item or {})
+      return { text = label }
     end,
-    deadline_date = function(ctx)
-      local task = ctx.item.item
-      if not task or not task.due then
-        return { text = "" }
+
+    -- Due-date chip:  2026-06-01
+    task_due = function(ctx)
+      local task = ctx.item.item or {}
+      local s = deadline_date_str(task.due) or ""
+      return { text = s ~= "" and (" " .. s) or "", hl = "Comment" }
+    end,
+
+    -- Status icon: ○ todo  ◑ doing  ✓ done
+    task_status = function(ctx)
+      local status = (ctx.item.item or {}).status
+      if     status == "Doing" then return { text = "◑ ", hl = "DiagnosticWarn" }
+      elseif status == "Done"  then return { text = "✓ ", hl = "DiagnosticOk"   }
+      else                          return { text = "○ ", hl = "Comment"        }
       end
-      
-      local due_str = ""
-      if type(task.due) == "table" then
-        if task.due.Date then
-          due_str = task.due.Date
-        elseif task.due.DateTime then
-          due_str = string.match(task.due.DateTime, "^[^T]+")
-        elseif task.due.Uninterpretable then
-          due_str = task.due.Uninterpretable
-        end
+    end,
+
+    -- time_spent chip:  ⏱ 1h30m  (hidden when absent)
+    task_time_spent = function(ctx)
+      local ts = (ctx.item.item or {}).time_spent
+      if not ts or type(ts) ~= "table" then return { text = "" } end
+      local h, m = ts.hours or 0, ts.minutes or 0
+      local s
+      if     h > 0 and m > 0 then s = string.format("⏱ %dh%dm", h, m)
+      elseif h > 0            then s = string.format("⏱ %dh",    h)
+      else                         s = string.format("⏱ %dm",    m)
       end
-      
-      return {
-        text = due_str,
-        hl = "Comment",
-      }
+      return { text = " " .. s, hl = "DiagnosticInfo" }
+    end,
+
+    -- started_at chip:  ▶ HH:MM  (visible only while clocked in)
+    task_started_at = function(ctx)
+      local sa = (ctx.item.item or {}).started_at
+      if not sa or type(sa) ~= "table" then return { text = "" } end
+      local dt = sa.DateTime
+      if not dt then return { text = "" } end
+      local hm = string.match(dt, "T(%d%d:%d%d)")
+      if not hm then return { text = "" } end
+      return { text = " ▶ " .. hm, hl = "DiagnosticWarn" }
     end,
   },
+
   sorters = {
     deadline = function(item)
-      -- Return the numeric sort key (timestamp) for sorting by deadline
-      local _, sort_key = parse_deadline(item.item or {})
-      return sort_key
+      local _, key = classify_due(item.item or {})
+      return key
     end,
   },
+
   modes = {
     patto_tasks = {
-      mode = "patto_tasks",
-      events = { "BufEnter", "BufWritePost", "InsertLeave"},
+      mode   = "patto_tasks",
+      events = { "BufEnter", "BufWritePost", "InsertLeave" },
       source = "patto_tasks",
-      desc = "Tasks grouped by deadline",
+      desc   = "Tasks grouped by deadline",
       groups = {
         { "deadline_group", format = "{deadline_group}" },
-        --{ "filename", format = "{file_icon} {filename}" },
       },
-      sort = { "deadline", "filename", "pos" },
-      --format = "{deadline_date} {text}",
-      format = "{deadline_date} {text} {filename}",
-      win = {
-        position = "bottom",
-        size = 0.25,
-      },
+      sort   = { "deadline", "filename", "pos" },
+      -- Format: status icon | label | due chip | time chips | file
+      format = "{task_status}{text}{task_due}{task_time_spent}{task_started_at} {filename}",
+      win = { position = "bottom", size = 0.25 },
     },
   },
 }
 
---- Fetch tasks from Patto LSP server
---- @param cb function Callback to receive items
+-- ── source.get ───────────────────────────────────────────────────────────────
+
 function M.get(cb)
-  -- Find any patto buffer to make LSP request from
   local patto_bufnr = nil
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-    if vim.api.nvim_buf_is_loaded(bufnr) and vim.bo[bufnr].filetype == 'patto' then
+    if vim.api.nvim_buf_is_loaded(bufnr) and vim.bo[bufnr].filetype == "patto" then
       patto_bufnr = bufnr
       break
     end
   end
 
-  if not patto_bufnr then
-    cb({})
-    return
-  end
+  if not patto_bufnr then cb({}) return end
 
-  vim.lsp.buf_request_all(patto_bufnr, 'workspace/executeCommand', {
-    command = 'experimental/aggregate_tasks',
+  vim.lsp.buf_request_all(patto_bufnr, "workspace/executeCommand", {
+    command   = "experimental/aggregate_tasks",
     arguments = {},
-  }, function(results, _ctx, _config)
+  }, function(results)
     local items = {} ---@type trouble.Item[]
-    
-    if not results then
-      cb(items)
-      return
-    end
+
+    if not results then cb(items) return end
 
     for _, vres in pairs(results) do
-      if vres.result == nil then
-        goto continue
-      end
-      
+      if vres.result == nil then goto continue end
+
       for _, task in ipairs(vres.result) do
-        local row = task.location.range.start.line + 1
+        local row = task.location.range.start.line      + 1
         local col = task.location.range.start.character + 1
-        local deadline_group, _ = parse_deadline(task)
-        
+        local bucket, _ = classify_due(task)
+
         items[#items + 1] = Item.new({
-          buf = vim.fn.bufadd(vim.uri_to_fname(task.location.uri)),
-          pos = { row, col },
-          end_pos = { row, col },
-          text = task.text,
-          filename = vim.uri_to_fname(task.location.uri),
-          item = task,
-          source = "patto_tasks",
-          deadline_group = deadline_group,
+          buf          = vim.fn.bufadd(vim.uri_to_fname(task.location.uri)),
+          pos          = { row, col },
+          end_pos      = { row, col },
+          text         = task.text,
+          filename     = vim.uri_to_fname(task.location.uri),
+          item         = task,
+          source       = "patto_tasks",
+          deadline_group = bucket,
         })
       end
       ::continue::
     end
-    
+
     cb(items)
   end)
 end

--- a/lua/trouble/sources/patto_tasks_review.lua
+++ b/lua/trouble/sources/patto_tasks_review.lua
@@ -90,7 +90,7 @@ M.config = {
       },
       sort   = { "completed_date_group_order", "completed_at", "filename", "pos" },
       -- Format: label | completed chip | time chip | file
-      format = "{text} {task_completed_at}{task_time_spent} {filename}",
+      format = "{task_completed_at} {text}{task_time_spent} {filename}",
       win    = { position = "bottom", size = 0.20 },
     },
   },

--- a/lua/trouble/sources/patto_tasks_review.lua
+++ b/lua/trouble/sources/patto_tasks_review.lua
@@ -4,103 +4,101 @@ local Item = require("trouble.item")
 ---@type trouble.Source
 local M = {}
 
---- Classify a "YYYY-MM-DD" completed_at string into a display bucket.
---- Buckets (most recent first): Today, Yesterday, This Week, Last Week, This Month, Older
---- Returns: bucket label (string), sort key (number, lower = more recent)
-local function classify_date(date_str)
-  if not date_str or date_str == "" then
-    return "Older", 1
-  end
-  local y, mo, d = string.match(date_str, "^(%d%d%d%d)%-(%d%d)%-(%d%d)$")
-  if not y then
-    return "Older", 1
-  end
+-- ── helpers ──────────────────────────────────────────────────────────────────
 
-  local completed_ts = os.time({ year = tonumber(y), month = tonumber(mo), day = tonumber(d), hour = 12, min = 0, sec = 0 })
+--- Classify a "YYYY-MM-DD" string into a recency bucket.
+--- Returns: label (string), sort order (number, higher = more recent)
+local function classify_completed(date_str)
+  if not date_str or date_str == "" then return "  Older", 1 end
+  local y, mo, d = string.match(date_str, "^(%d%d%d%d)%-(%d%d)%-(%d%d)")
+  if not y then return "  Older", 1 end
 
-  local now = os.time()
-  local t = os.date("*t", now) --[[@as table]]
-  local today_start  = os.time({ year = t.year, month = t.month, day = t.day,     hour = 0, min = 0, sec = 0 })
-  local today_end    = today_start + 86400 - 1
+  local ts   = os.time({ year = tonumber(y), month = tonumber(mo), day = tonumber(d),
+                          hour = 12, min = 0, sec = 0 })
+  local now  = os.time()
+  local t    = os.date("*t", now) --[[@as table]]
+  local today_start = os.time({ year = t.year, month = t.month, day = t.day,
+                                  hour = 0, min = 0, sec = 0 })
   local yest_start   = today_start - 86400
-  local yest_end     = today_start - 1
-
-  -- Monday of this week
-  local days_since_mon = (t.wday - 2) % 7  -- wday: 1=Sun, 2=Mon
+  local days_since_mon = (t.wday - 2) % 7
   local this_week_start = today_start - days_since_mon * 86400
   local last_week_start = this_week_start - 7 * 86400
-  local last_week_end   = this_week_start - 1
+  local month_start = os.time({ year = t.year, month = t.month, day = 1,
+                                  hour = 0, min = 0, sec = 0 })
 
-  -- First day of this month
-  local month_start = os.time({ year = t.year, month = t.month, day = 1, hour = 0, min = 0, sec = 0 })
-
-  if completed_ts >= today_start and completed_ts <= today_end then
-    return "📅 Today", 6
-  elseif completed_ts >= yest_start and completed_ts <= yest_end then
-    return "📅 Yesterday", 5
-  elseif completed_ts >= this_week_start then
-    return "📅 This Week", 4
-  elseif completed_ts >= last_week_start and completed_ts <= last_week_end then
-    return "📅 Last Week", 3
-  elseif completed_ts >= month_start then
-    return "📅 This Month", 2
-  else
-    return "📅 Older", 1
+  if ts >= today_start      then return "Today",      6
+  elseif ts >= yest_start   then return "Yesterday",  5
+  elseif ts >= this_week_start then return "This Week", 4
+  elseif ts >= last_week_start then return "Last Week", 3
+  elseif ts >= month_start  then return "This Month", 2
+  else                           return "Older",      1
   end
 end
+
+-- ── formatters ───────────────────────────────────────────────────────────────
 
 ---@diagnostic disable-next-line: missing-fields
 M.config = {
   formatters = {
-    completed_at = function(ctx)
-      return {
-        text = (ctx.item.item or {}).completed_at or "",
-        hl = "Comment",
-      }
-    end,
+    -- Group header
     completed_date_group = function(ctx)
-      return {
-        text = ctx.item.completed_date_group or "Older",
-      }
+      return { text = ctx.item.completed_date_group or "  Older" }
+    end,
+
+    -- completed_at chip:  ✓ 2026-05-19
+    task_completed_at = function(ctx)
+      local s = (ctx.item.item or {}).completed_at or ""
+      return { text = s ~= "" and ("✓ " .. s) or "", hl = "DiagnosticOk" }
+    end,
+
+    -- time_spent chip:  ⏱ 1h30m
+    task_time_spent = function(ctx)
+      local ts = (ctx.item.item or {}).time_spent
+      if not ts or type(ts) ~= "table" then return { text = "" } end
+      local h, m = ts.hours or 0, ts.minutes or 0
+      local s
+      if     h > 0 and m > 0 then s = string.format("⏱ %dh%dm", h, m)
+      elseif h > 0            then s = string.format("⏱ %dh",    h)
+      else                         s = string.format("⏱ %dm",    m)
+      end
+      return { text = " " .. s, hl = "DiagnosticInfo" }
     end,
   },
+
   sorters = {
     completed_at = function(item)
-      local date_str = (item.item or {}).completed_at
-      if not date_str or date_str == "" then return 0 end
-      local y, mo, d = string.match(date_str, "^(%d%d%d%d)%-(%d%d)%-(%d%d)$")
+      local s = (item.item or {}).completed_at
+      if not s then return 0 end
+      local y, mo, d = string.match(s, "^(%d%d%d%d)%-(%d%d)%-(%d%d)")
       if not y then return 0 end
-      return os.time({ year = tonumber(y), month = tonumber(mo), day = tonumber(d), hour = 12, min = 0, sec = 0 })
+      return os.time({ year = tonumber(y), month = tonumber(mo), day = tonumber(d),
+                       hour = 12, min = 0, sec = 0 })
     end,
     completed_date_group_order = function(item)
       return item.completed_date_group_order or 1
     end,
   },
+
   modes = {
     patto_tasks_review = {
-      mode = "patto_tasks_review",
+      mode   = "patto_tasks_review",
       events = { "BufWritePost" },
       source = "patto_tasks_review",
-      desc = "Completed tasks grouped by recency (today/yesterday/this week/last week/this month)",
+      desc   = "Completed tasks grouped by recency",
       groups = {
         { "completed_date_group", format = "{completed_date_group}" },
       },
-      sort = { "completed_date_group_order", "completed_at", "filename", "pos" },
-      format = "{completed_at} {text} {filename}",
-      win = {
-        position = "bottom",
-        size = 0.20,
-      },
+      sort   = { "completed_date_group_order", "completed_at", "filename", "pos" },
+      -- Format: label | completed chip | time chip | file
+      format = "{text} {task_completed_at}{task_time_spent} {filename}",
+      win    = { position = "bottom", size = 0.20 },
     },
   },
 }
 
---- Fetch completed tasks from Patto LSP server
---- Computes "recent" range client-side (start of last week or month, whichever earlier, through today)
---- and sends as custom date range to the backend.
---- @param cb function Callback to receive items
---- @param ctx table Trouble source context
-function M.get(cb, ctx)
+-- ── source.get ───────────────────────────────────────────────────────────────
+
+function M.get(cb, _ctx)
   local patto_bufnr = nil
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     if vim.api.nvim_buf_is_loaded(bufnr) and vim.bo[bufnr].filetype == "patto" then
@@ -109,51 +107,43 @@ function M.get(cb, ctx)
     end
   end
 
-  if not patto_bufnr then
-    cb({})
-    return
-  end
+  if not patto_bufnr then cb({}) return end
 
-  -- Compute "recent" range: from (start of last week OR start of this month, whichever earlier) through today
-  local now = os.time()
-  local t = os.date("*t", now) --[[@as table]]
+  -- Compute range: from (start of last week OR start of this month, whichever earlier) through today.
+  local now   = os.time()
+  local t     = os.date("*t", now) --[[@as table]]
   local today_str = os.date("%Y-%m-%d", now)
-  local days_since_mon = (t.wday - 2) % 7  -- wday: 1=Sun, 2=Mon
-  local last_week_start_ts = now - (days_since_mon + 7) * 86400
-  local month_start_ts = os.time({ year = t.year, month = t.month, day = 1, hour = 0, min = 0, sec = 0 })
-  local from_ts = math.min(last_week_start_ts, month_start_ts)
-  local from_str = os.date("%Y-%m-%d", from_ts)
+  local days_since_mon   = (t.wday - 2) % 7
+  local last_week_start  = now - (days_since_mon + 7) * 86400
+  local month_start      = os.time({ year = t.year, month = t.month, day = 1,
+                                      hour = 0, min = 0, sec = 0 })
+  local from_str = os.date("%Y-%m-%d", math.min(last_week_start, month_start))
 
   vim.lsp.buf_request_all(patto_bufnr, "workspace/executeCommand", {
-    command = "experimental/tasks_review",
+    command   = "experimental/tasks_review",
     arguments = { "custom", from_str, today_str },
-  }, function(results, _ctx, _config)
+  }, function(results)
     local items = {} ---@type trouble.Item[]
 
-    if not results then
-      cb(items)
-      return
-    end
+    if not results then cb(items) return end
 
     for _, vres in pairs(results) do
-      if vres.result == nil then
-        goto continue
-      end
+      if vres.result == nil then goto continue end
 
       for _, task in ipairs(vres.result) do
-        local row = task.location.range.start.line + 1
+        local row = task.location.range.start.line      + 1
         local col = task.location.range.start.character + 1
-        local bucket, order = classify_date(task.completed_at)
+        local bucket, order = classify_completed(task.completed_at)
 
         items[#items + 1] = Item.new({
-          buf                       = vim.fn.bufadd(vim.uri_to_fname(task.location.uri)),
-          pos                       = { row, col },
-          end_pos                   = { row, col },
-          text                      = task.text,
-          filename                  = vim.uri_to_fname(task.location.uri),
-          item                      = task,
-          source                    = "patto_tasks_review",
-          completed_date_group      = bucket,
+          buf                        = vim.fn.bufadd(vim.uri_to_fname(task.location.uri)),
+          pos                        = { row, col },
+          end_pos                    = { row, col },
+          text                       = task.text,
+          filename                   = vim.uri_to_fname(task.location.uri),
+          item                       = task,
+          source                     = "patto_tasks_review",
+          completed_date_group       = bucket,
           completed_date_group_order = order,
         })
       end

--- a/settings/vimlsp.vim
+++ b/settings/vimlsp.vim
@@ -84,10 +84,10 @@ function! s:show_task(res) abort
         let l:path = lsp#utils#uri_to_path(l:item['location']['uri'])
         let [l:line, l:col] = lsp#utils#position#lsp_to_vim(l:path, l:item['location']['range']['start'])
 
-        " Build a rich display string: label + structured chips
-        let l:parts = [l:item['text']]
+        " Build a rich display string: due date + label + chips
+        let l:parts = []
 
-        " due date chip
+        " due date chip first
         let l:due = get(l:item, 'due', v:null)
         if type(l:due) == v:t_dict
             let l:due_str = get(l:due, 'Date', get(l:due, 'DateTime', ''))
@@ -97,6 +97,8 @@ function! s:show_task(res) abort
                 call add(l:parts, '[due:' . l:due_str . ']')
             endif
         endif
+
+        call add(l:parts, l:item['text'])
 
         " status chip (only show non-todo)
         let l:status = get(l:item, 'status', '')

--- a/settings/vimlsp.vim
+++ b/settings/vimlsp.vim
@@ -83,11 +83,46 @@ function! s:show_task(res) abort
     for l:item in a:res
         let l:path = lsp#utils#uri_to_path(l:item['location']['uri'])
         let [l:line, l:col] = lsp#utils#position#lsp_to_vim(l:path, l:item['location']['range']['start'])
+
+        " Build a rich display string: label + structured chips
+        let l:parts = [l:item['text']]
+
+        " due date chip
+        let l:due = get(l:item, 'due', v:null)
+        if type(l:due) == v:t_dict
+            let l:due_str = get(l:due, 'Date', get(l:due, 'DateTime', ''))
+            if l:due_str !=# ''
+                " Trim datetime to date portion
+                let l:due_str = substitute(l:due_str, 'T.*$', '', '')
+                call add(l:parts, '[due:' . l:due_str . ']')
+            endif
+        endif
+
+        " status chip (only show non-todo)
+        let l:status = get(l:item, 'status', '')
+        if l:status ==# 'Doing'
+            call add(l:parts, '[doing]')
+        endif
+
+        " time_spent chip
+        let l:ts = get(l:item, 'time_spent', v:null)
+        if type(l:ts) == v:t_dict
+            let l:h = get(l:ts, 'hours', 0)
+            let l:m = get(l:ts, 'minutes', 0)
+            if l:h > 0 && l:m > 0
+                call add(l:parts, '[' . l:h . 'h' . l:m . 'm]')
+            elseif l:h > 0
+                call add(l:parts, '[' . l:h . 'h]')
+            elseif l:m > 0
+                call add(l:parts, '[' . l:m . 'm]')
+            endif
+        endif
+
         call add(l:list, {
                     \ 'filename': l:path,
                     \ 'lnum':     l:line,
                     \ 'col':      l:col,
-                    \ 'text':     l:item['text']
+                    \ 'text':     join(l:parts, ' '),
                     \ })
     endfor
 
@@ -279,11 +314,32 @@ function! s:show_tasks_review(res, label) abort
     for l:task in a:res
         let l:path = lsp#utils#uri_to_path(l:task['location']['uri'])
         let [l:line, l:col] = lsp#utils#position#lsp_to_vim(l:path, l:task['location']['range']['start'])
+
+        " Build display: [completed_at] label [time_spent]
+        let l:parts = []
+        let l:cat = get(l:task, 'completed_at', '')
+        if type(l:cat) == v:t_string && l:cat !=# ''
+            call add(l:parts, '[' . l:cat . ']')
+        endif
+        call add(l:parts, l:task['text'])
+        let l:ts = get(l:task, 'time_spent', v:null)
+        if type(l:ts) == v:t_dict
+            let l:h = get(l:ts, 'hours', 0)
+            let l:m = get(l:ts, 'minutes', 0)
+            if l:h > 0 && l:m > 0
+                call add(l:parts, '[' . l:h . 'h' . l:m . 'm]')
+            elseif l:h > 0
+                call add(l:parts, '[' . l:h . 'h]')
+            elseif l:m > 0
+                call add(l:parts, '[' . l:m . 'm]')
+            endif
+        endif
+
         call add(l:list, {
                     \ 'filename': l:path,
                     \ 'lnum':     l:line,
                     \ 'col':      l:col,
-                    \ 'text':     '[' . l:task['completed_at'] . '] ' . l:task['text'],
+                    \ 'text':     join(l:parts, ' '),
                     \ })
     endfor
 

--- a/src/bin/patto-lsp.rs
+++ b/src/bin/patto-lsp.rs
@@ -66,6 +66,7 @@ async fn main() {
             root_uri: Arc::new(Mutex::new(None)),
             paper_catalog: shared_catalog.clone(),
             settings: Arc::new(Mutex::new(PattoSettings::default())),
+            last_valid_task_snapshots: Arc::new(dashmap::DashMap::new()),
         }
     });
     log::info!("Patto Language Server Protocol started");

--- a/src/importer/converter.rs
+++ b/src/importer/converter.rs
@@ -401,9 +401,12 @@ impl MarkdownImporter {
 
                                 Some(vec![Property::Task {
                                     status,
+                                    status_is_canonical: true,
                                     due,
                                     scheduled,
                                     completed_at,
+                                    started_at: None,
+                                    time_spent: None,
                                     location: crate::parser::Location::default(),
                                 }])
                             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub mod repository;
 pub mod semantic_token;
 #[cfg(feature = "preview-tui")]
 pub mod syntax_highlight;
+pub mod task;
 #[cfg(feature = "preview-tui")]
 pub mod tui_renderer;
-pub mod task;
 pub mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,4 +11,5 @@ pub mod semantic_token;
 pub mod syntax_highlight;
 #[cfg(feature = "preview-tui")]
 pub mod tui_renderer;
+pub mod task;
 pub mod utils;

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -201,13 +201,32 @@ pub struct TaskInformation {
     /// The location of this task
     pub location: Location,
 
-    /// The text of this task
+    /// Human-readable label: raw line text with the task property token removed.
     pub text: String,
 
     pub message: String,
 
     /// The deadline of this task
     pub due: Deadline,
+
+    /// Optional scheduled date
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheduled: Option<Deadline>,
+
+    /// Optional completion timestamp
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<Deadline>,
+
+    /// Optional clock-in timestamp (currently running session)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<Deadline>,
+
+    /// Accumulated time spent
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_spent: Option<crate::task::Duration>,
+
+    /// Task status
+    pub status: TaskStatus,
 }
 
 impl TaskInformation {
@@ -217,8 +236,58 @@ impl TaskInformation {
             text,
             message,
             due,
+            scheduled: None,
+            completed_at: None,
+            started_at: None,
+            time_spent: None,
+            status: TaskStatus::Todo,
         }
     }
+}
+
+/// Return the line text with the task property token stripped and whitespace trimmed.
+/// e.g. "buy milk {@task status=todo due=2026-06-01}" → "buy milk"
+fn task_label(line: &AstNode) -> String {
+    if let AstNodeKind::Line { properties } = &line.kind() {
+        for prop in properties {
+            if let Property::Task { location, .. } = prop {
+                let raw = line.extract_str();
+                // Remove the property span (byte offsets) and collapse extra whitespace.
+                let before = raw[..location.span.0.min(raw.len())].trim_end();
+                let after  = raw[location.span.1.min(raw.len())..].trim_start();
+                return match (before.is_empty(), after.is_empty()) {
+                    (true,  true)  => String::new(),
+                    (false, true)  => before.trim_start().to_string(),
+                    (true,  false) => after.trim_start().to_string(),
+                    (false, false) => format!("{} {}", before.trim_start(), after),
+                };
+            }
+        }
+    }
+    line.extract_str().trim_start().to_string()
+}
+
+/// Build a TaskInformation from an AstNode that has a Task property.
+fn task_information(uri: &tower_lsp::lsp_types::Url, line: &AstNode, due: &Deadline) -> TaskInformation {
+    let mut info = TaskInformation::new(
+        Location::new(uri.clone(), get_node_range(line)),
+        task_label(line),
+        String::new(),
+        due.clone(),
+    );
+    if let AstNodeKind::Line { properties } = &line.kind() {
+        for prop in properties {
+            if let Property::Task { status, scheduled, completed_at, started_at, time_spent, .. } = prop {
+                info.status       = status.clone();
+                info.scheduled    = scheduled.clone();
+                info.completed_at = completed_at.clone();
+                info.started_at   = started_at.clone();
+                info.time_spent   = time_spent.clone();
+                break;
+            }
+        }
+    }
+    info
 }
 
 fn find_anchor(parent: &AstNode, anchor: &str) -> Option<AstNode> {
@@ -1020,14 +1089,7 @@ impl LanguageServer for Backend {
                 let tasks = repo.aggregate_tasks();
                 let ret = json!(tasks
                     .iter()
-                    .map(|(uri, line, due)| {
-                        TaskInformation::new(
-                            Location::new(uri.clone(), get_node_range(line)),
-                            line.extract_str().trim_start().to_string(),
-                            "".to_string(),
-                            due.clone(),
-                        )
-                    })
+                    .map(|(uri, line, due)| task_information(uri, line, due))
                     .collect::<Vec<_>>());
                 return Ok(Some(ret));
             }
@@ -1090,10 +1152,18 @@ impl LanguageServer for Backend {
                 let ret = json!(tasks
                     .iter()
                     .map(|(uri, line, date)| {
+                        let mut info = task_information(uri, line, &crate::parser::Deadline::Date(*date));
+                        // Override completed_at with the authoritative value from repository
+                        // (already set by task_information, but ensure the date string matches)
                         json!({
-                            "location": Location::new(uri.clone(), get_node_range(line)),
-                            "text": line.extract_str().trim_start(),
+                            "location":    info.location,
+                            "text":        info.text,
+                            "status":      info.status,
+                            "due":         info.due,
+                            "scheduled":   info.scheduled,
                             "completed_at": date.format("%Y-%m-%d").to_string(),
+                            "started_at":  info.started_at,
+                            "time_spent":  info.time_spent,
                         })
                     })
                     .collect::<Vec<_>>());

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use urlencoding::decode;
 
+use dashmap::DashMap;
 use str_indices::utf16::{from_byte_idx as utf16_from_byte_idx, to_byte_idx as utf16_to_byte_idx};
 
 use super::paper::{PaperCatalog, PaperProviderError};
@@ -16,7 +17,7 @@ use crate::markdown::{MarkdownFlavor, MarkdownRendererOptions};
 use crate::parser::{
     self, AstNode, AstNodeKind, Deadline, ParserResult, PattoLineParser, Property, Rule, TaskStatus,
 };
-use crate::renderer::{MarkdownRenderer, Renderer};
+use crate::lsp::task_edits::{collect_task_snapshots, detect_task_transitions, generate_edits_for_transition};use crate::renderer::{MarkdownRenderer, Renderer};
 use crate::repository::{Repository, RepositoryMessage};
 use crate::semantic_token::{get_semantic_tokens, get_semantic_tokens_range, LEGEND_TYPE};
 use pest::Parser as _;
@@ -48,7 +49,10 @@ pub struct Backend {
     pub root_uri: Arc<Mutex<Option<Url>>>,
     pub paper_catalog: PaperCatalog,
     pub settings: Arc<Mutex<PattoSettings>>,
-    //semantic_token_map: DashMap<String, Vec<ImCompleteSemanticToken>>,
+    /// Last *valid* (successfully parsed) task snapshot per file, keyed by row.
+    /// Retained across keystrokes so that mid-edit parse failures (e.g. `status=`)
+    /// don't lose the `Doing` state needed to compute elapsed time on clock-out.
+    pub last_valid_task_snapshots: Arc<DashMap<Url, HashMap<usize, crate::task::TaskSnapshot>>>,
 }
 
 fn get_node_range(from: &AstNode) -> Range {
@@ -317,186 +321,70 @@ impl Backend {
         let uri = Repository::normalize_url_percent_encoding(&params.uri);
 
         if let Ok(file_path) = uri.to_file_path() {
-            // Fetch old AST before the graph is updated
-            let old_ast: Option<AstNode> = self
+            // Update graph with new content.
+            if let Some(repo) = self.repository.lock().unwrap().as_ref() {
+                repo.add_file_to_graph(&file_path, &params.text);
+            }
+
+            // Fetch the new AST and compute task snapshots for this version.
+            let new_ast: Option<AstNode> = self
                 .repository
                 .lock()
                 .unwrap()
                 .as_ref()
                 .and_then(|repo| repo.ast_map.get(&uri).map(|e| e.value().clone()));
 
-            // Update graph with new content
-            if let Some(repo) = self.repository.lock().unwrap().as_ref() {
-                repo.add_file_to_graph(&file_path, &params.text);
-            }
+            if let Some(new_ast) = new_ast {
+                let now = chrono::Local::now().naive_local();
+                let new_snapshots = collect_task_snapshots(&new_ast);
 
-            // Fetch new AST and compare to detect task completions
-            if let Some(old_ast) = old_ast {
-                let new_ast: Option<AstNode> = self
-                    .repository
-                    .lock()
-                    .unwrap()
-                    .as_ref()
-                    .and_then(|repo| repo.ast_map.get(&uri).map(|e| e.value().clone()));
+                // Retrieve the sticky old snapshots (last valid state per row).
+                // These survive keystrokes where the task is temporarily unparseable
+                // (e.g. `status=` during a `doing`→`todo` edit).
+                let old_snapshots: HashMap<usize, crate::task::TaskSnapshot> = self
+                    .last_valid_task_snapshots
+                    .get(&uri)
+                    .map(|e| e.value().clone())
+                    .unwrap_or_default();
 
-                if let Some(new_ast) = new_ast {
-                    let mut edits = Vec::new();
-                    self.collect_completion_edits(&old_ast, &new_ast, &mut edits);
-                    if !edits.is_empty() {
-                        let workspace_edit = WorkspaceEdit {
-                            changes: Some([(uri.clone(), edits)].iter().cloned().collect()),
-                            document_changes: None,
-                            change_annotations: None,
-                        };
-                        let _ = self.client.apply_edit(workspace_edit).await;
+                // Update the sticky map: only overwrite rows where the new snapshot
+                // has a canonical status value. Non-canonical mid-edit states (e.g.
+                // `status=doin`) are ignored so the previous Doing state is preserved.
+                {
+                    let mut entry = self
+                        .last_valid_task_snapshots
+                        .entry(uri.clone())
+                        .or_default();
+                    for (row, snap) in &new_snapshots {
+                        if snap.status_is_canonical {
+                            entry.insert(*row, snap.clone());
+                        }
                     }
+                }
+
+                let transitions = detect_task_transitions(&new_snapshots, &old_snapshots);
+
+                let edits: Vec<tower_lsp::lsp_types::TextEdit> = transitions
+                    .iter()
+                    .flat_map(|t| generate_edits_for_transition(t, now))
+                    .collect();
+
+                if !edits.is_empty() {
+                    let workspace_edit = WorkspaceEdit {
+                        changes: Some([(uri.clone(), edits)].iter().cloned().collect()),
+                        document_changes: None,
+                        change_annotations: None,
+                    };
+                    let _ = self.client.apply_edit(workspace_edit).await;
                 }
             }
         }
 
-        // Parse for diagnostics (this is LSP-specific, not handled by repository)
+        // Parse for diagnostics (LSP-specific, not handled by repository).
         let (_, diagnostics) = parse_text(&params.text);
-
-        // Publish diagnostics to the client
         self.client
             .publish_diagnostics(params.uri.clone(), diagnostics, Some(params.version))
             .await;
-    }
-
-    /// Collect old task statuses (by line row) from the AST into a map.
-    fn collect_old_task_statuses(
-        node: &AstNode,
-        map: &mut HashMap<usize, (TaskStatus, Option<Deadline>)>,
-    ) {
-        if let AstNodeKind::Line { properties } = &node.kind() {
-            for prop in properties {
-                if let Property::Task {
-                    status,
-                    completed_at,
-                    ..
-                } = prop
-                {
-                    map.insert(node.location().row, (status.clone(), completed_at.clone()));
-                    break;
-                }
-            }
-        }
-        for child in node.value().children.lock().unwrap().iter() {
-            Self::collect_old_task_statuses(child, map);
-        }
-    }
-
-    /// Walk the new AST to find tasks that just transitioned to Done without a completed_at,
-    /// and generate the corresponding TextEdit for each.
-    fn find_newly_completed_tasks(
-        &self,
-        node: &AstNode,
-        old_statuses: &HashMap<usize, (TaskStatus, Option<Deadline>)>,
-        edits: &mut Vec<TextEdit>,
-    ) {
-        if let AstNodeKind::Line { properties } = &node.kind() {
-            for prop in properties {
-                if let Property::Task {
-                    status: new_status,
-                    completed_at: None,
-                    ..
-                } = prop
-                {
-                    if *new_status == TaskStatus::Done {
-                        let row = node.location().row;
-                        let was_not_done = old_statuses
-                            .get(&row)
-                            .map(|(old_status, _)| *old_status != TaskStatus::Done)
-                            .unwrap_or(false);
-                        if was_not_done {
-                            if let Some(edit) = self.generate_completed_at_edit_from_node(node) {
-                                edits.push(edit);
-                            }
-                        }
-                    }
-                    break;
-                }
-            }
-        }
-        for child in node.value().children.lock().unwrap().iter() {
-            self.find_newly_completed_tasks(child, old_statuses, edits);
-        }
-    }
-
-    pub fn collect_completion_edits(
-        &self,
-        old_ast: &AstNode,
-        new_ast: &AstNode,
-        edits: &mut Vec<TextEdit>,
-    ) {
-        let mut old_statuses = HashMap::new();
-        Self::collect_old_task_statuses(old_ast, &mut old_statuses);
-        self.find_newly_completed_tasks(new_ast, &old_statuses, edits);
-    }
-
-    fn generate_completed_at_edit_from_node(&self, line_node: &AstNode) -> Option<TextEdit> {
-        let line_content = line_node.extract_str();
-        let line_idx = line_node.location().row as u32;
-
-        // If line already has completed_at, don't add it again
-        if line_content.contains("completed_at=") {
-            return None;
-        }
-
-        let now = chrono::Local::now().format("%Y-%m-%dT%H:%M").to_string();
-
-        if line_content.contains("{@task") {
-            // Insert completed_at= into an existing {@task ...} block before the closing }
-            if let Some(close_brace_idx) = line_content.rfind('}') {
-                let new_text = format!(" completed_at={}", now);
-                return Some(TextEdit {
-                    range: Range {
-                        start: Position {
-                            line: line_idx,
-                            character: utf16_from_byte_idx(line_content, close_brace_idx) as u32,
-                        },
-                        end: Position {
-                            line: line_idx,
-                            character: utf16_from_byte_idx(line_content, close_brace_idx) as u32,
-                        },
-                    },
-                    new_text,
-                });
-            }
-        } else {
-            // Shorthand task (e.g. `-2024-12-31`): replace it with the long {@task} form
-            // so we can include completed_at without creating a duplicate property.
-            if let AstNodeKind::Line { properties } = &line_node.kind() {
-                for prop in properties {
-                    if let Property::Task {
-                        status: TaskStatus::Done,
-                        due,
-                        location,
-                        ..
-                    } = prop
-                    {
-                        let span = &location.span;
-                        let new_text =
-                            format!("{{@task status=done due={} completed_at={}}}", due, now);
-                        return Some(TextEdit {
-                            range: Range {
-                                start: Position {
-                                    line: line_idx,
-                                    character: utf16_from_byte_idx(line_content, span.0) as u32,
-                                },
-                                end: Position {
-                                    line: line_idx,
-                                    character: utf16_from_byte_idx(line_content, span.1) as u32,
-                                },
-                            },
-                            new_text,
-                        });
-                    }
-                }
-            }
-        }
-
-        None
     }
 
     async fn start_repository_listener(&self) {

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -13,11 +13,14 @@ use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
 
 use crate::diagnostic_translator::{DiagnosticTranslator, FriendlyDiagnostic};
+use crate::lsp::task_edits::{
+    collect_task_snapshots, detect_task_transitions, generate_edits_for_transition,
+};
 use crate::markdown::{MarkdownFlavor, MarkdownRendererOptions};
 use crate::parser::{
     self, AstNode, AstNodeKind, Deadline, ParserResult, PattoLineParser, Property, Rule, TaskStatus,
 };
-use crate::lsp::task_edits::{collect_task_snapshots, detect_task_transitions, generate_edits_for_transition};use crate::renderer::{MarkdownRenderer, Renderer};
+use crate::renderer::{MarkdownRenderer, Renderer};
 use crate::repository::{Repository, RepositoryMessage};
 use crate::semantic_token::{get_semantic_tokens, get_semantic_tokens_range, LEGEND_TYPE};
 use pest::Parser as _;
@@ -254,11 +257,11 @@ fn task_label(line: &AstNode) -> String {
                 let raw = line.extract_str();
                 // Remove the property span (byte offsets) and collapse extra whitespace.
                 let before = raw[..location.span.0.min(raw.len())].trim_end();
-                let after  = raw[location.span.1.min(raw.len())..].trim_start();
+                let after = raw[location.span.1.min(raw.len())..].trim_start();
                 return match (before.is_empty(), after.is_empty()) {
-                    (true,  true)  => String::new(),
-                    (false, true)  => before.trim_start().to_string(),
-                    (true,  false) => after.trim_start().to_string(),
+                    (true, true) => String::new(),
+                    (false, true) => before.trim_start().to_string(),
+                    (true, false) => after.trim_start().to_string(),
                     (false, false) => format!("{} {}", before.trim_start(), after),
                 };
             }
@@ -268,7 +271,11 @@ fn task_label(line: &AstNode) -> String {
 }
 
 /// Build a TaskInformation from an AstNode that has a Task property.
-fn task_information(uri: &tower_lsp::lsp_types::Url, line: &AstNode, due: &Deadline) -> TaskInformation {
+fn task_information(
+    uri: &tower_lsp::lsp_types::Url,
+    line: &AstNode,
+    due: &Deadline,
+) -> TaskInformation {
     let mut info = TaskInformation::new(
         Location::new(uri.clone(), get_node_range(line)),
         task_label(line),
@@ -277,12 +284,20 @@ fn task_information(uri: &tower_lsp::lsp_types::Url, line: &AstNode, due: &Deadl
     );
     if let AstNodeKind::Line { properties } = &line.kind() {
         for prop in properties {
-            if let Property::Task { status, scheduled, completed_at, started_at, time_spent, .. } = prop {
-                info.status       = status.clone();
-                info.scheduled    = scheduled.clone();
+            if let Property::Task {
+                status,
+                scheduled,
+                completed_at,
+                started_at,
+                time_spent,
+                ..
+            } = prop
+            {
+                info.status = status.clone();
+                info.scheduled = scheduled.clone();
                 info.completed_at = completed_at.clone();
-                info.started_at   = started_at.clone();
-                info.time_spent   = time_spent.clone();
+                info.started_at = started_at.clone();
+                info.time_spent = time_spent.clone();
                 break;
             }
         }
@@ -1152,7 +1167,8 @@ impl LanguageServer for Backend {
                 let ret = json!(tasks
                     .iter()
                     .map(|(uri, line, date)| {
-                        let mut info = task_information(uri, line, &crate::parser::Deadline::Date(*date));
+                        let mut info =
+                            task_information(uri, line, &crate::parser::Deadline::Date(*date));
                         // Override completed_at with the authoritative value from repository
                         // (already set by task_information, but ensure the date string matches)
                         json!({

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1,6 +1,7 @@
 pub mod backend;
 pub mod lsp_config;
 pub mod paper;
+pub mod task_edits;
 
 pub use backend::Backend;
 pub use backend::{MarkdownSettings, PattoSettings};

--- a/src/lsp/task_edits.rs
+++ b/src/lsp/task_edits.rs
@@ -188,7 +188,11 @@ pub fn generate_edits_for_transition(
             // Similarly, use the larger of new/old time_spent as the base so
             // we never lose accumulated time from a previous session.
             let base_time_spent = match (&new.time_spent, &old.time_spent) {
-                (Some(n), Some(o)) => Some(if n.total_minutes() >= o.total_minutes() { n.clone() } else { o.clone() }),
+                (Some(n), Some(o)) => Some(if n.total_minutes() >= o.total_minutes() {
+                    n.clone()
+                } else {
+                    o.clone()
+                }),
                 (Some(n), None) => Some(n.clone()),
                 (None, Some(o)) => Some(o.clone()),
                 (None, None) => None,
@@ -221,7 +225,11 @@ pub fn generate_edits_for_transition(
             // Fall back to old snapshot in case the user also deleted it.
             let started_at = new.started_at.as_ref().or(old.started_at.as_ref());
             let base_time_spent = match (&new.time_spent, &old.time_spent) {
-                (Some(n), Some(o)) => Some(if n.total_minutes() >= o.total_minutes() { n.clone() } else { o.clone() }),
+                (Some(n), Some(o)) => Some(if n.total_minutes() >= o.total_minutes() {
+                    n.clone()
+                } else {
+                    o.clone()
+                }),
                 (Some(n), None) => Some(n.clone()),
                 (None, Some(o)) => Some(o.clone()),
                 (None, None) => None,
@@ -290,21 +298,21 @@ fn build_edits(snapshot: &TaskSnapshot, fields: &[(&str, String)]) -> Vec<TextEd
 /// - If the value is empty, delete the existing `key=value` (and any leading space).
 fn build_longform_edits(snapshot: &TaskSnapshot, fields: &[(&str, String)]) -> Vec<TextEdit> {
     let line = snapshot.prop_span.0; // row (0-indexed)
-    // We need the raw line text — extract from the snapshot's prop_span context.
-    // The Location stores the full line input as `input`.
-    // We reconstruct it from the AstNode indirectly via the span; however we
-    // don't have the AstNode here.  Instead we locate the text via the
-    // `prop_span` within the source string that we do not store in TaskSnapshot.
-    //
-    // To keep TaskSnapshot lean we store the raw line string in the snapshot
-    // itself.  We add a `line_text` field to TaskSnapshot below, OR we accept
-    // the text via a parameter.
-    //
-    // **Design decision**: accept `line_text` as an argument so we can stay pure.
-    // This is called from `generate_edits_for_transition` which has no line text.
-    //
-    // ► We propagate line_text through TaskSnapshot instead.
-    //   (See the `line_text` field added to TaskSnapshot in src/task.rs.)
+                                     // We need the raw line text — extract from the snapshot's prop_span context.
+                                     // The Location stores the full line input as `input`.
+                                     // We reconstruct it from the AstNode indirectly via the span; however we
+                                     // don't have the AstNode here.  Instead we locate the text via the
+                                     // `prop_span` within the source string that we do not store in TaskSnapshot.
+                                     //
+                                     // To keep TaskSnapshot lean we store the raw line string in the snapshot
+                                     // itself.  We add a `line_text` field to TaskSnapshot below, OR we accept
+                                     // the text via a parameter.
+                                     //
+                                     // **Design decision**: accept `line_text` as an argument so we can stay pure.
+                                     // This is called from `generate_edits_for_transition` which has no line text.
+                                     //
+                                     // ► We propagate line_text through TaskSnapshot instead.
+                                     //   (See the `line_text` field added to TaskSnapshot in src/task.rs.)
 
     // For now, build a single replacement edit that rewrites the entire property
     // block.  This is simpler than per-field surgery and avoids offset
@@ -313,7 +321,10 @@ fn build_longform_edits(snapshot: &TaskSnapshot, fields: &[(&str, String)]) -> V
 }
 
 /// Rewrite the full `{@task …}` block in one edit, merging new field values.
-fn build_longform_full_rewrite(snapshot: &TaskSnapshot, new_fields: &[(&str, String)]) -> Vec<TextEdit> {
+fn build_longform_full_rewrite(
+    snapshot: &TaskSnapshot,
+    new_fields: &[(&str, String)],
+) -> Vec<TextEdit> {
     use crate::parser::Deadline;
 
     // Start from the snapshot's current field values.
@@ -411,7 +422,10 @@ fn build_longform_full_rewrite(snapshot: &TaskSnapshot, new_fields: &[(&str, Str
 }
 
 /// Replace the shorthand token with a full `{@task …}` block.
-fn build_shorthand_replacement(snapshot: &TaskSnapshot, new_fields: &[(&str, String)]) -> Vec<TextEdit> {
+fn build_shorthand_replacement(
+    snapshot: &TaskSnapshot,
+    new_fields: &[(&str, String)],
+) -> Vec<TextEdit> {
     // Delegate to the same full-rewrite logic — shorthand has no existing long
     // form, so rewriting the span (shorthand token) with `{@task …}` is correct.
     build_longform_full_rewrite(snapshot, new_fields)
@@ -423,8 +437,8 @@ fn build_shorthand_replacement(snapshot: &TaskSnapshot, new_fields: &[(&str, Str
 mod tests {
     use super::*;
     use crate::parser::Deadline;
-    use crate::task::{Duration, TaskSnapshot, TaskTransition};
     use crate::parser::TaskStatus;
+    use crate::task::{Duration, TaskSnapshot, TaskTransition};
 
     fn make_snapshot(row: usize, status: TaskStatus, started_at: Option<&str>) -> TaskSnapshot {
         TaskSnapshot {
@@ -480,7 +494,10 @@ mod tests {
     fn detect_doing_to_todo() {
         let old = {
             let mut m = HashMap::new();
-            m.insert(0, make_snapshot(0, TaskStatus::Doing, Some("2026-05-19T09:00")));
+            m.insert(
+                0,
+                make_snapshot(0, TaskStatus::Doing, Some("2026-05-19T09:00")),
+            );
             m
         };
         let new = {

--- a/src/lsp/task_edits.rs
+++ b/src/lsp/task_edits.rs
@@ -1,0 +1,515 @@
+/// Generic task-diff and edit-generation pipeline.
+///
+/// # Architecture
+///
+/// ```text
+/// old AST  ──► collect_task_snapshots ──► HashMap<row, TaskSnapshot>
+///                                                     │
+/// new AST  ──► collect_task_snapshots ──► HashMap<row, TaskSnapshot>
+///                                                     │
+///                          detect_task_transitions ◄──┘
+///                                     │
+///                      Vec<TaskTransition>
+///                                     │
+///              generate_edits_for_transition  (per transition)
+///                                     │
+///                          Vec<TextEdit>  ──► workspace/applyEdit
+/// ```
+///
+/// All edit-generation is span-based (using `Property::location.span` from the
+/// parsed AST) and never scans raw text with `rfind` or `contains`.
+use std::collections::HashMap;
+
+use str_indices::utf16::from_byte_idx as utf16_from_byte_idx;
+use tower_lsp::lsp_types::{Position, Range, TextEdit};
+
+use crate::parser::{AstNode, AstNodeKind, Property, TaskStatus};
+use crate::task::{Duration, TaskSnapshot, TaskTransition};
+
+// ─── AST walk ────────────────────────────────────────────────────────────────
+
+/// Walk every `(line_node, Property::Task)` pair in the AST tree, calling `f`
+/// for each one found.  Children are visited recursively after the current node.
+pub fn walk_task_lines(node: &AstNode, f: &mut impl FnMut(&AstNode, &Property)) {
+    let props: Option<&Vec<Property>> = match node.kind() {
+        AstNodeKind::Line { properties } => Some(properties),
+        AstNodeKind::QuoteContent { properties } => Some(properties),
+        _ => None,
+    };
+
+    if let Some(properties) = props {
+        for prop in properties {
+            if matches!(prop, Property::Task { .. }) {
+                f(node, prop);
+                break; // at most one Task property per line
+            }
+        }
+    }
+
+    for child in node.value().children.lock().unwrap().iter() {
+        walk_task_lines(child, f);
+    }
+}
+
+// ─── Snapshot collection ─────────────────────────────────────────────────────
+
+/// Convert an entire AST into a row-keyed map of `TaskSnapshot`s.
+///
+/// This is the *only* place that pattern-matches on `Property::Task` fields —
+/// all subsequent logic works on `TaskSnapshot` values.
+pub fn collect_task_snapshots(root: &AstNode) -> HashMap<usize, TaskSnapshot> {
+    let mut map = HashMap::new();
+    walk_task_lines(root, &mut |node, prop| {
+        if let Property::Task {
+            status,
+            status_is_canonical,
+            due,
+            scheduled,
+            completed_at,
+            started_at,
+            time_spent,
+            location,
+        } = prop
+        {
+            let line_text = node.extract_str().to_string();
+            // Determine whether the on-disk form is a shorthand token.
+            // Shorthand tokens start with a single ASCII symbol (`-`/`*`/`!`)
+            // followed immediately by a digit, not with `{@`.
+            let prop_text = &line_text[location.span.0..location.span.1.min(line_text.len())];
+            let is_shorthand = !prop_text.starts_with("{@");
+
+            map.insert(
+                node.location().row,
+                TaskSnapshot {
+                    row: node.location().row,
+                    status: status.clone(),
+                    status_is_canonical: *status_is_canonical,
+                    due: due.clone(),
+                    scheduled: scheduled.clone(),
+                    completed_at: completed_at.clone(),
+                    started_at: started_at.clone(),
+                    time_spent: time_spent.clone(),
+                    prop_span: location.span.clone(),
+                    is_shorthand,
+                    line_text,
+                },
+            );
+        }
+    });
+    map
+}
+
+// ─── Transition detection ─────────────────────────────────────────────────────
+
+/// Compare old and new snapshot maps and return every detected `TaskTransition`.
+///
+/// Rules:
+/// - `* → Done` without a `completed_at` already set  → `BecameDone`
+/// - `* → Doing` without a `started_at` already set   → `BecameDoing`
+/// - `Doing → Todo`                                    → `BecameTodo`  (clock-out)
+pub fn detect_task_transitions(
+    new_snapshots: &HashMap<usize, TaskSnapshot>,
+    old_snapshots: &HashMap<usize, TaskSnapshot>,
+) -> Vec<TaskTransition> {
+    let mut transitions = Vec::new();
+
+    for (row, new) in new_snapshots {
+        let old = match old_snapshots.get(row) {
+            // Brand-new task line (no previous snapshot): skip auto-edits.
+            None => continue,
+            Some(o) => o,
+        };
+
+        // Skip transitions involving non-canonical status values (e.g. `status=doin`
+        // during a mid-word edit). Both sides must be canonical to avoid spurious
+        // clock-in/out events during keystroke-by-keystroke changes.
+        if !new.status_is_canonical || !old.status_is_canonical {
+            continue;
+        }
+
+        match (&new.status, &old.status) {
+            // ── Any → Done ─────────────────────────────────────────────────
+            (TaskStatus::Done, prev) if *prev != TaskStatus::Done => {
+                // Only inject completed_at if it is not already present.
+                if new.completed_at.is_none() {
+                    transitions.push(TaskTransition::BecameDone {
+                        old: old.clone(),
+                        new: new.clone(),
+                    });
+                }
+            }
+
+            // ── Any → Doing ────────────────────────────────────────────────
+            (TaskStatus::Doing, prev) if *prev != TaskStatus::Doing => {
+                // Only inject started_at if it is not already present.
+                if new.started_at.is_none() {
+                    transitions.push(TaskTransition::BecameDoing {
+                        old: old.clone(),
+                        new: new.clone(),
+                    });
+                }
+            }
+
+            // ── Doing → Todo ───────────────────────────────────────────────
+            (TaskStatus::Todo, TaskStatus::Doing) => {
+                transitions.push(TaskTransition::BecameTodo {
+                    old: old.clone(),
+                    new: new.clone(),
+                });
+            }
+
+            _ => {}
+        }
+    }
+
+    transitions
+}
+
+// ─── Edit generation ─────────────────────────────────────────────────────────
+
+/// Generate all `TextEdit`s required to record time-tracking data for one
+/// `TaskTransition`.  The `now` timestamp is passed in so callers can use a
+/// consistent timestamp for a batch of edits.
+pub fn generate_edits_for_transition(
+    transition: &TaskTransition,
+    now: chrono::NaiveDateTime,
+) -> Vec<TextEdit> {
+    match transition {
+        // ── BecameDone ────────────────────────────────────────────────────
+        TaskTransition::BecameDone { old, new } => {
+            // Fields to set: completed_at=<now>
+            // Also flush started_at → time_spent if the task was clocked in.
+            //
+            // Prefer `new.started_at` over `old.started_at`: the editor will
+            // have sent back a did_change that includes the injected started_at
+            // field, so the new snapshot is more likely to have it.  Fall back
+            // to old in case the applyEdit round-trip hasn't completed yet.
+            let started_at = new.started_at.as_ref().or(old.started_at.as_ref());
+            // Similarly, use the larger of new/old time_spent as the base so
+            // we never lose accumulated time from a previous session.
+            let base_time_spent = match (&new.time_spent, &old.time_spent) {
+                (Some(n), Some(o)) => Some(if n.total_minutes() >= o.total_minutes() { n.clone() } else { o.clone() }),
+                (Some(n), None) => Some(n.clone()),
+                (None, Some(o)) => Some(o.clone()),
+                (None, None) => None,
+            };
+
+            let mut fields: Vec<(&str, String)> = Vec::new();
+            let elapsed = elapsed_since(&started_at.cloned(), now);
+
+            if let Some(e) = elapsed {
+                let total = base_time_spent.unwrap_or_default() + e;
+                fields.push(("time_spent", total.to_string()));
+                fields.push(("started_at", String::new())); // delete
+            }
+
+            fields.push(("completed_at", now.format("%Y-%m-%dT%H:%M").to_string()));
+
+            build_edits(new, &fields)
+        }
+
+        // ── BecameDoing ───────────────────────────────────────────────────
+        TaskTransition::BecameDoing { new, .. } => {
+            let fields = vec![("started_at", now.format("%Y-%m-%dT%H:%M").to_string())];
+            build_edits(new, &fields)
+        }
+
+        // ── BecameTodo (clock-out without Done) ───────────────────────────
+        TaskTransition::BecameTodo { old, new } => {
+            // Prefer started_at from the new snapshot (it may still be present
+            // in the line text if the user only changed the status word).
+            // Fall back to old snapshot in case the user also deleted it.
+            let started_at = new.started_at.as_ref().or(old.started_at.as_ref());
+            let base_time_spent = match (&new.time_spent, &old.time_spent) {
+                (Some(n), Some(o)) => Some(if n.total_minutes() >= o.total_minutes() { n.clone() } else { o.clone() }),
+                (Some(n), None) => Some(n.clone()),
+                (None, Some(o)) => Some(o.clone()),
+                (None, None) => None,
+            };
+
+            let elapsed = elapsed_since(&started_at.cloned(), now);
+            if let Some(e) = elapsed {
+                let total = base_time_spent.unwrap_or_default() + e;
+                let fields = vec![
+                    ("time_spent", total.to_string()),
+                    ("started_at", String::new()), // delete
+                ];
+                build_edits(new, &fields)
+            } else {
+                // No started_at recorded anywhere — nothing to do
+                vec![]
+            }
+        }
+    }
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/// Compute elapsed time between `started_at` and `now`.
+/// Returns `None` if `started_at` is absent or not a DateTime.
+fn elapsed_since(
+    started_at: &Option<crate::parser::Deadline>,
+    now: chrono::NaiveDateTime,
+) -> Option<Duration> {
+    use crate::parser::Deadline;
+    let start = match started_at.as_ref()? {
+        Deadline::DateTime(dt) => *dt,
+        Deadline::Date(d) => d.and_hms_opt(0, 0, 0)?,
+        Deadline::Uninterpretable(_) => return None,
+    };
+    let secs = (now - start).num_seconds();
+    if secs <= 0 {
+        return None;
+    }
+    Some(Duration::from_minutes((secs / 60) as u32))
+}
+
+/// Build the actual `TextEdit` list that inserts / updates / deletes fields
+/// inside (or replacing) the task property token.
+///
+/// `fields` is a list of `(key, value)` pairs.  An **empty value string**
+/// means "delete this key" (i.e. remove the `key=value` pair from the block).
+///
+/// Two strategies:
+/// - **Long-form** (`{@task …}`): each field is either inserted before `}` or
+///   the existing `key=oldvalue` span is replaced in-place.
+/// - **Shorthand** (`-YYYY-MM-DD`): the entire span is replaced with a full
+///   `{@task …}` block that includes all existing fields plus the new ones.
+fn build_edits(snapshot: &TaskSnapshot, fields: &[(&str, String)]) -> Vec<TextEdit> {
+    if snapshot.is_shorthand {
+        build_shorthand_replacement(snapshot, fields)
+    } else {
+        build_longform_edits(snapshot, fields)
+    }
+}
+
+/// For a long-form `{@task …}` block, generate one `TextEdit` per field.
+///
+/// - If the field already exists, replace the value span.
+/// - If the field is new (and value is non-empty), insert before the closing `}`.
+/// - If the value is empty, delete the existing `key=value` (and any leading space).
+fn build_longform_edits(snapshot: &TaskSnapshot, fields: &[(&str, String)]) -> Vec<TextEdit> {
+    let line = snapshot.prop_span.0; // row (0-indexed)
+    // We need the raw line text — extract from the snapshot's prop_span context.
+    // The Location stores the full line input as `input`.
+    // We reconstruct it from the AstNode indirectly via the span; however we
+    // don't have the AstNode here.  Instead we locate the text via the
+    // `prop_span` within the source string that we do not store in TaskSnapshot.
+    //
+    // To keep TaskSnapshot lean we store the raw line string in the snapshot
+    // itself.  We add a `line_text` field to TaskSnapshot below, OR we accept
+    // the text via a parameter.
+    //
+    // **Design decision**: accept `line_text` as an argument so we can stay pure.
+    // This is called from `generate_edits_for_transition` which has no line text.
+    //
+    // ► We propagate line_text through TaskSnapshot instead.
+    //   (See the `line_text` field added to TaskSnapshot in src/task.rs.)
+
+    // For now, build a single replacement edit that rewrites the entire property
+    // block.  This is simpler than per-field surgery and avoids offset
+    // calculation complexity when multiple fields change simultaneously.
+    build_longform_full_rewrite(snapshot, fields)
+}
+
+/// Rewrite the full `{@task …}` block in one edit, merging new field values.
+fn build_longform_full_rewrite(snapshot: &TaskSnapshot, new_fields: &[(&str, String)]) -> Vec<TextEdit> {
+    use crate::parser::Deadline;
+
+    // Start from the snapshot's current field values.
+    let mut status = snapshot.status.clone();
+    let mut due = snapshot.due.clone();
+    let mut scheduled = snapshot.scheduled.clone();
+    let mut completed_at = snapshot.completed_at.clone();
+    let mut started_at = snapshot.started_at.clone();
+    let mut time_spent = snapshot.time_spent.clone();
+
+    // Apply overrides from `new_fields`.
+    for (key, value) in new_fields {
+        match *key {
+            "status" => {
+                status = match value.as_str() {
+                    "todo" => TaskStatus::Todo,
+                    "doing" => TaskStatus::Doing,
+                    "done" => TaskStatus::Done,
+                    _ => status,
+                };
+            }
+            "completed_at" => {
+                if value.is_empty() {
+                    completed_at = None;
+                } else {
+                    completed_at = Some(crate::parser::parse_deadline_pub(value));
+                }
+            }
+            "started_at" => {
+                if value.is_empty() {
+                    started_at = None;
+                } else {
+                    started_at = Some(crate::parser::parse_deadline_pub(value));
+                }
+            }
+            "time_spent" => {
+                if value.is_empty() {
+                    time_spent = None;
+                } else {
+                    time_spent = value.parse().ok();
+                }
+            }
+            "scheduled" => {
+                if value.is_empty() {
+                    scheduled = None;
+                } else {
+                    scheduled = Some(crate::parser::parse_deadline_pub(value));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let status_str = match status {
+        TaskStatus::Todo => "todo",
+        TaskStatus::Doing => "doing",
+        TaskStatus::Done => "done",
+    };
+
+    let mut parts = vec![format!("status={}", status_str)];
+
+    if !matches!(due, Deadline::Uninterpretable(ref s) if s.is_empty()) {
+        parts.push(format!("due={}", due));
+    }
+    if let Some(s) = &scheduled {
+        parts.push(format!("scheduled={}", s));
+    }
+    if let Some(c) = &completed_at {
+        parts.push(format!("completed_at={}", c));
+    }
+    if let Some(sa) = &started_at {
+        parts.push(format!("started_at={}", sa));
+    }
+    if let Some(ts) = &time_spent {
+        parts.push(format!("time_spent={}", ts));
+    }
+
+    let new_text = format!("{{@task {}}}", parts.join(" "));
+
+    let line_idx = snapshot.row as u32;
+    let line_text = &snapshot.line_text;
+    vec![TextEdit {
+        range: Range {
+            start: Position {
+                line: line_idx,
+                character: utf16_from_byte_idx(line_text, snapshot.prop_span.0) as u32,
+            },
+            end: Position {
+                line: line_idx,
+                character: utf16_from_byte_idx(line_text, snapshot.prop_span.1) as u32,
+            },
+        },
+        new_text,
+    }]
+}
+
+/// Replace the shorthand token with a full `{@task …}` block.
+fn build_shorthand_replacement(snapshot: &TaskSnapshot, new_fields: &[(&str, String)]) -> Vec<TextEdit> {
+    // Delegate to the same full-rewrite logic — shorthand has no existing long
+    // form, so rewriting the span (shorthand token) with `{@task …}` is correct.
+    build_longform_full_rewrite(snapshot, new_fields)
+}
+
+// ─── Unit tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::Deadline;
+    use crate::task::{Duration, TaskSnapshot, TaskTransition};
+    use crate::parser::TaskStatus;
+
+    fn make_snapshot(row: usize, status: TaskStatus, started_at: Option<&str>) -> TaskSnapshot {
+        TaskSnapshot {
+            row,
+            status,
+            status_is_canonical: true,
+            due: Deadline::Uninterpretable("".to_string()),
+            scheduled: None,
+            completed_at: None,
+            started_at: started_at.map(|s| crate::parser::parse_deadline_pub(s)),
+            time_spent: None,
+            prop_span: crate::parser::Span(0, 10),
+            is_shorthand: false,
+            line_text: "{@task status=todo due=}".to_string(),
+        }
+    }
+
+    #[test]
+    fn detect_todo_to_done() {
+        let old = {
+            let mut m = HashMap::new();
+            m.insert(0, make_snapshot(0, TaskStatus::Todo, None));
+            m
+        };
+        let new = {
+            let mut m = HashMap::new();
+            m.insert(0, make_snapshot(0, TaskStatus::Done, None));
+            m
+        };
+        let transitions = detect_task_transitions(&new, &old);
+        assert_eq!(transitions.len(), 1);
+        assert!(matches!(transitions[0], TaskTransition::BecameDone { .. }));
+    }
+
+    #[test]
+    fn detect_todo_to_doing() {
+        let old = {
+            let mut m = HashMap::new();
+            m.insert(0, make_snapshot(0, TaskStatus::Todo, None));
+            m
+        };
+        let new = {
+            let mut m = HashMap::new();
+            m.insert(0, make_snapshot(0, TaskStatus::Doing, None));
+            m
+        };
+        let transitions = detect_task_transitions(&new, &old);
+        assert_eq!(transitions.len(), 1);
+        assert!(matches!(transitions[0], TaskTransition::BecameDoing { .. }));
+    }
+
+    #[test]
+    fn detect_doing_to_todo() {
+        let old = {
+            let mut m = HashMap::new();
+            m.insert(0, make_snapshot(0, TaskStatus::Doing, Some("2026-05-19T09:00")));
+            m
+        };
+        let new = {
+            let mut m = HashMap::new();
+            m.insert(0, make_snapshot(0, TaskStatus::Todo, None));
+            m
+        };
+        let transitions = detect_task_transitions(&new, &old);
+        assert_eq!(transitions.len(), 1);
+        assert!(matches!(transitions[0], TaskTransition::BecameTodo { .. }));
+    }
+
+    #[test]
+    fn no_transition_when_done_already_has_completed_at() {
+        let old = {
+            let mut m = HashMap::new();
+            m.insert(0, make_snapshot(0, TaskStatus::Todo, None));
+            m
+        };
+        let new = {
+            let mut m = HashMap::new();
+            let mut snap = make_snapshot(0, TaskStatus::Done, None);
+            snap.completed_at = Some(Deadline::Date(
+                chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            ));
+            m.insert(0, snap);
+            m
+        };
+        let transitions = detect_task_transitions(&new, &old);
+        assert_eq!(transitions.len(), 0);
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1655,9 +1655,18 @@ fn transform_property(
 
                                 if key == "status" {
                                     status = match value {
-                                        "todo" => { status_is_canonical = true; TaskStatus::Todo }
-                                        "doing" | "inprogress" | "wip" => { status_is_canonical = true; TaskStatus::Doing }
-                                        "done" => { status_is_canonical = true; TaskStatus::Done }
+                                        "todo" => {
+                                            status_is_canonical = true;
+                                            TaskStatus::Todo
+                                        }
+                                        "doing" | "inprogress" | "wip" => {
+                                            status_is_canonical = true;
+                                            TaskStatus::Doing
+                                        }
+                                        "done" => {
+                                            status_is_canonical = true;
+                                            TaskStatus::Done
+                                        }
                                         _ => {
                                             log::warn!(
                                                 "Unknown task status: '{}', interpreted as 'todo'",
@@ -1687,9 +1696,18 @@ fn transform_property(
                                 let value = kv.as_str();
                                 if current_key == "status" {
                                     status = match value {
-                                        "todo" => { status_is_canonical = true; TaskStatus::Todo }
-                                        "doing" => { status_is_canonical = true; TaskStatus::Doing }
-                                        "done" => { status_is_canonical = true; TaskStatus::Done }
+                                        "todo" => {
+                                            status_is_canonical = true;
+                                            TaskStatus::Todo
+                                        }
+                                        "doing" => {
+                                            status_is_canonical = true;
+                                            TaskStatus::Doing
+                                        }
+                                        "done" => {
+                                            status_is_canonical = true;
+                                            TaskStatus::Done
+                                        }
                                         _ => {
                                             log::warn!(
                                                 "Unknown task status: '{}', interpreted as 'todo'",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -175,7 +175,7 @@ impl fmt::Display for Deadline {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Deadline::DateTime(dt) => {
-                write!(f, "{}", dt)?;
+                write!(f, "{}", dt.format("%Y-%m-%dT%H:%M"))?;
             }
             Deadline::Date(d) => {
                 write!(f, "{}", d)?;
@@ -226,9 +226,16 @@ pub enum TaskStatus {
 pub enum Property {
     Task {
         status: TaskStatus,
+        /// `false` if the status value was unrecognised (partial edit); transitions
+        /// involving a non-canonical status are skipped by the diff logic.
+        status_is_canonical: bool,
         due: Deadline,
         scheduled: Option<Deadline>,
         completed_at: Option<Deadline>,
+        /// Timestamp of the most recent clock-in (set when transitioning to Doing).
+        started_at: Option<Deadline>,
+        /// Accumulated time spent across all completed sessions.
+        time_spent: Option<crate::task::Duration>,
         location: Location,
     },
     Anchor {
@@ -1574,6 +1581,11 @@ fn transform_embed<'a>(
     }
 }
 
+/// Helper to parse deadline strings (public re-export for use in edit generation).
+pub fn parse_deadline_pub(value: &str) -> Deadline {
+    parse_deadline(value)
+}
+
 /// Helper to parse deadline strings
 fn parse_deadline(value: &str) -> Deadline {
     if let Ok(datetime) = chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M") {
@@ -1625,9 +1637,12 @@ fn transform_property(
                 "task" => {
                     // Task property: {@task status=todo due=2024-12-31 scheduled=2024-12-30 completed_at=2024-12-31}
                     let mut status = TaskStatus::Todo;
+                    let mut status_is_canonical = false;
                     let mut due = Deadline::Uninterpretable("".to_string());
                     let mut scheduled: Option<Deadline> = None;
                     let mut completed_at: Option<Deadline> = None;
+                    let mut started_at: Option<Deadline> = None;
+                    let mut time_spent: Option<crate::task::Duration> = None;
                     let mut current_key = "";
 
                     for kv in inner {
@@ -1640,9 +1655,9 @@ fn transform_property(
 
                                 if key == "status" {
                                     status = match value {
-                                        "todo" => TaskStatus::Todo,
-                                        "doing" | "inprogress" | "wip" => TaskStatus::Doing,
-                                        "done" => TaskStatus::Done,
+                                        "todo" => { status_is_canonical = true; TaskStatus::Todo }
+                                        "doing" | "inprogress" | "wip" => { status_is_canonical = true; TaskStatus::Doing }
+                                        "done" => { status_is_canonical = true; TaskStatus::Done }
                                         _ => {
                                             log::warn!(
                                                 "Unknown task status: '{}', interpreted as 'todo'",
@@ -1657,6 +1672,10 @@ fn transform_property(
                                     scheduled = Some(parse_deadline(value));
                                 } else if key == "completed_at" {
                                     completed_at = Some(parse_deadline(value));
+                                } else if key == "started_at" {
+                                    started_at = Some(parse_deadline(value));
+                                } else if key == "time_spent" {
+                                    time_spent = value.parse().ok();
                                 } else {
                                     log::warn!("Unknown task property key: {}", key);
                                 }
@@ -1668,9 +1687,9 @@ fn transform_property(
                                 let value = kv.as_str();
                                 if current_key == "status" {
                                     status = match value {
-                                        "todo" => TaskStatus::Todo,
-                                        "doing" => TaskStatus::Doing,
-                                        "done" => TaskStatus::Done,
+                                        "todo" => { status_is_canonical = true; TaskStatus::Todo }
+                                        "doing" => { status_is_canonical = true; TaskStatus::Doing }
+                                        "done" => { status_is_canonical = true; TaskStatus::Done }
                                         _ => {
                                             log::warn!(
                                                 "Unknown task status: '{}', interpreted as 'todo'",
@@ -1685,6 +1704,10 @@ fn transform_property(
                                     scheduled = Some(parse_deadline(value));
                                 } else if current_key == "completed_at" {
                                     completed_at = Some(parse_deadline(value));
+                                } else if current_key == "started_at" {
+                                    started_at = Some(parse_deadline(value));
+                                } else if current_key == "time_spent" {
+                                    time_spent = value.parse().ok();
                                 } else {
                                     log::warn!("Unknown task property value: {}", value);
                                 }
@@ -1702,9 +1725,12 @@ fn transform_property(
                     }
                     Some(Property::Task {
                         status,
+                        status_is_canonical,
                         due,
                         scheduled,
                         completed_at,
+                        started_at,
+                        time_spent,
                         location,
                     })
                 }
@@ -1727,9 +1753,12 @@ fn transform_property(
             let due = parse_deadline(due_str);
             Some(Property::Task {
                 status,
+                status_is_canonical: true,
                 due,
                 scheduled: None,
                 completed_at: None,
+                started_at: None,
+                time_spent: None,
                 location,
             })
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -215,7 +215,7 @@ impl Ord for Deadline {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum TaskStatus {
     Todo,
     Doing,

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,0 +1,238 @@
+/// Task time tracking types and transition detection helpers.
+///
+/// This module centralises all domain types that describe the *state* of a task
+/// and the *transitions* between states.  Edit-generation lives in
+/// `crate::lsp::task_edits` so that LSP-specific types (TextEdit, Position, …)
+/// are not pulled into the core domain layer.
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::parser::{Deadline, TaskStatus};
+
+// ─── Duration ────────────────────────────────────────────────────────────────
+
+/// A human-readable duration stored as whole hours + minutes.
+///
+/// Canonical serialised form: `1h30m`, `45m`, `2h`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct Duration {
+    pub hours: u32,
+    pub minutes: u32,
+}
+
+impl Duration {
+    pub fn new(hours: u32, minutes: u32) -> Self {
+        let total_minutes = hours * 60 + minutes;
+        Self {
+            hours: total_minutes / 60,
+            minutes: total_minutes % 60,
+        }
+    }
+
+    pub fn from_minutes(total: u32) -> Self {
+        Self {
+            hours: total / 60,
+            minutes: total % 60,
+        }
+    }
+
+    pub fn total_minutes(&self) -> u32 {
+        self.hours * 60 + self.minutes
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.hours == 0 && self.minutes == 0
+    }
+}
+
+impl std::ops::Add for Duration {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        Self::from_minutes(self.total_minutes() + rhs.total_minutes())
+    }
+}
+
+impl std::ops::AddAssign for Duration {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = Self::from_minutes(self.total_minutes() + rhs.total_minutes());
+    }
+}
+
+impl fmt::Display for Duration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (self.hours, self.minutes) {
+            (h, 0) => write!(f, "{}h", h),
+            (0, m) => write!(f, "{}m", m),
+            (h, m) => write!(f, "{}h{}m", h, m),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParseDurationError;
+
+impl fmt::Display for ParseDurationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid duration string (expected NhMm / Nh / Mm)")
+    }
+}
+
+impl FromStr for Duration {
+    type Err = ParseDurationError;
+
+    /// Accepts `"1h30m"`, `"2h"`, `"45m"`, `"0h"`, `"0m"`.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+        if s.is_empty() {
+            return Err(ParseDurationError);
+        }
+
+        let mut hours: u32 = 0;
+        let mut minutes: u32 = 0;
+        let mut rest = s;
+
+        if let Some(h_pos) = rest.find('h') {
+            hours = rest[..h_pos].parse().map_err(|_| ParseDurationError)?;
+            rest = &rest[h_pos + 1..];
+        }
+
+        if let Some(m_pos) = rest.find('m') {
+            minutes = rest[..m_pos].parse().map_err(|_| ParseDurationError)?;
+            rest = &rest[m_pos + 1..];
+        }
+
+        // Trailing garbage → error
+        if !rest.is_empty() {
+            return Err(ParseDurationError);
+        }
+
+        // Must have consumed at least one unit
+        if s.find('h').is_none() && s.find('m').is_none() {
+            return Err(ParseDurationError);
+        }
+
+        Ok(Self::new(hours, minutes))
+    }
+}
+
+// ─── TaskSnapshot ─────────────────────────────────────────────────────────────
+
+/// A complete snapshot of one task line's state, captured from the AST.
+///
+/// Both the old and new AST are converted to `HashMap<usize, TaskSnapshot>`
+/// (keyed by line row) so that the diff logic only deals with `TaskSnapshot`
+/// values instead of raw `Property` pattern-matches.
+#[derive(Debug, Clone)]
+pub struct TaskSnapshot {
+    pub row: usize,
+    pub status: TaskStatus,
+    pub due: Deadline,
+    pub scheduled: Option<Deadline>,
+    pub completed_at: Option<Deadline>,
+    pub started_at: Option<Deadline>,
+    pub time_spent: Option<Duration>,
+    /// Byte span of the entire task property token within the line string.
+    /// Used by edit generators to avoid re-scanning raw text.
+    pub prop_span: crate::parser::Span,
+    /// Is the status value a recognised canonical keyword (`todo`/`doing`/`done`
+    /// and aliases)?  `false` when the parser fell back to the default because
+    /// the value was unrecognised (e.g. `status=doin` during a mid-edit keystroke).
+    /// Transitions from/to non-canonical states are ignored by the diff logic.
+    pub status_is_canonical: bool,
+    /// Is the on-disk form a shorthand token (`-YYYY-MM-DD`) rather than a
+    /// full `{@task …}` block?
+    pub is_shorthand: bool,
+    /// Full raw text of the line that owns this task (needed for UTF-16 offset
+    /// conversion when generating edits).
+    pub line_text: String,
+}
+
+// ─── TaskTransition ───────────────────────────────────────────────────────────
+
+/// A detected state change for a single task line between two AST snapshots.
+#[derive(Debug)]
+pub enum TaskTransition {
+    /// Any status → Done (no `completed_at` present yet in the new snapshot).
+    BecameDone {
+        old: TaskSnapshot,
+        new: TaskSnapshot,
+    },
+    /// Any status → Doing (no `started_at` present yet in the new snapshot).
+    BecameDoing {
+        old: TaskSnapshot,
+        new: TaskSnapshot,
+    },
+    /// Doing → Todo (clock-out without completing; `time_spent` should be updated).
+    BecameTodo {
+        old: TaskSnapshot,
+        new: TaskSnapshot,
+    },
+}
+
+impl TaskTransition {
+    /// Row number of the affected line (from the *new* snapshot).
+    pub fn row(&self) -> usize {
+        match self {
+            TaskTransition::BecameDone { new, .. } => new.row,
+            TaskTransition::BecameDoing { new, .. } => new.row,
+            TaskTransition::BecameTodo { new, .. } => new.row,
+        }
+    }
+
+    pub fn new_snapshot(&self) -> &TaskSnapshot {
+        match self {
+            TaskTransition::BecameDone { new, .. } => new,
+            TaskTransition::BecameDoing { new, .. } => new,
+            TaskTransition::BecameTodo { new, .. } => new,
+        }
+    }
+
+    pub fn old_snapshot(&self) -> &TaskSnapshot {
+        match self {
+            TaskTransition::BecameDone { old, .. } => old,
+            TaskTransition::BecameDoing { old, .. } => old,
+            TaskTransition::BecameTodo { old, .. } => old,
+        }
+    }
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duration_roundtrip() {
+        // Canonical form: hours-only, minutes-only, or both.
+        // "0m" and "0h" both normalise to zero; "0h" is the canonical display.
+        for (input, expected) in &[
+            ("1h30m", "1h30m"),
+            ("2h", "2h"),
+            ("45m", "45m"),
+            ("0h", "0h"),
+            ("0m", "0h"),   // normalises to hours form
+            ("10h5m", "10h5m"),
+        ] {
+            let d: Duration = input.parse().unwrap();
+            assert_eq!(d.to_string(), *expected, "input={}", input);
+        }
+    }
+
+    #[test]
+    fn duration_add() {
+        let a = Duration::new(1, 45);
+        let b = Duration::new(0, 30);
+        assert_eq!(a + b, Duration::new(2, 15));
+    }
+
+    #[test]
+    fn duration_parse_errors() {
+        assert!("".parse::<Duration>().is_err());
+        assert!("abc".parse::<Duration>().is_err());
+        assert!("1h30".parse::<Duration>().is_err()); // trailing digits, no unit
+    }
+}
+

--- a/src/task.rs
+++ b/src/task.rs
@@ -213,7 +213,7 @@ mod tests {
             ("2h", "2h"),
             ("45m", "45m"),
             ("0h", "0h"),
-            ("0m", "0h"),   // normalises to hours form
+            ("0m", "0h"), // normalises to hours form
             ("10h5m", "10h5m"),
         ] {
             let d: Duration = input.parse().unwrap();
@@ -235,4 +235,3 @@ mod tests {
         assert!("1h30".parse::<Duration>().is_err()); // trailing digits, no unit
     }
 }
-

--- a/tests/common/in_process_client.rs
+++ b/tests/common/in_process_client.rs
@@ -313,7 +313,9 @@ impl InProcessLspClient {
         old_ast: &patto::parser::AstNode,
         new_ast: &patto::parser::AstNode,
     ) -> Vec<tower_lsp::lsp_types::TextEdit> {
-        use patto::lsp::task_edits::{collect_task_snapshots, detect_task_transitions, generate_edits_for_transition};
+        use patto::lsp::task_edits::{
+            collect_task_snapshots, detect_task_transitions, generate_edits_for_transition,
+        };
         let now = chrono::Local::now().naive_local();
         let old_snapshots = collect_task_snapshots(old_ast);
         let new_snapshots = collect_task_snapshots(new_ast);

--- a/tests/common/in_process_client.rs
+++ b/tests/common/in_process_client.rs
@@ -24,6 +24,7 @@ impl InProcessLspClient {
             root_uri: Arc::new(Mutex::new(None)),
             paper_catalog: PaperCatalog::default(),
             settings: Arc::new(Mutex::new(PattoSettings::default())),
+            last_valid_task_snapshots: Arc::new(dashmap::DashMap::new()),
         })
         .finish();
 
@@ -312,10 +313,15 @@ impl InProcessLspClient {
         old_ast: &patto::parser::AstNode,
         new_ast: &patto::parser::AstNode,
     ) -> Vec<tower_lsp::lsp_types::TextEdit> {
-        let mut edits = Vec::new();
-        self.backend
-            .collect_completion_edits(old_ast, new_ast, &mut edits);
-        edits
+        use patto::lsp::task_edits::{collect_task_snapshots, detect_task_transitions, generate_edits_for_transition};
+        let now = chrono::Local::now().naive_local();
+        let old_snapshots = collect_task_snapshots(old_ast);
+        let new_snapshots = collect_task_snapshots(new_ast);
+        let transitions = detect_task_transitions(&new_snapshots, &old_snapshots);
+        transitions
+            .iter()
+            .flat_map(|t| generate_edits_for_transition(t, now))
+            .collect()
     }
 
     /// Send a generic notification
@@ -330,5 +336,18 @@ impl InProcessLspClient {
                 self.backend.did_save(p).await;
             }
         }
+    }
+
+    /// Return the sticky last-valid task snapshots for a file (for testing the
+    /// keystroke-gap-bridging behaviour).
+    pub fn get_last_valid_task_snapshots(
+        &self,
+        uri: &tower_lsp::lsp_types::Url,
+    ) -> Option<std::collections::HashMap<usize, patto::task::TaskSnapshot>> {
+        let normalized = patto::repository::Repository::normalize_url_percent_encoding(uri);
+        self.backend
+            .last_valid_task_snapshots
+            .get(&normalized)
+            .map(|e| e.value().clone())
     }
 }

--- a/tests/lsp_task_time_tracking.rs
+++ b/tests/lsp_task_time_tracking.rs
@@ -1,7 +1,9 @@
 mod common;
 
 use common::*;
-use patto::lsp::task_edits::{collect_task_snapshots, detect_task_transitions, generate_edits_for_transition};
+use patto::lsp::task_edits::{
+    collect_task_snapshots, detect_task_transitions, generate_edits_for_transition,
+};
 use patto::parser::{parse_text, TaskStatus};
 use patto::task::TaskTransition;
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -92,7 +94,11 @@ async fn test_no_transition_for_already_done_with_completed_at() {
         "buy milk {@task status=todo due=2026-06-01}\n",
         "buy milk {@task status=done due=2026-06-01 completed_at=2026-05-18T10:00}\n",
     );
-    assert_eq!(ts.len(), 0, "No transition expected when completed_at already set");
+    assert_eq!(
+        ts.len(),
+        0,
+        "No transition expected when completed_at already set"
+    );
 }
 
 #[tokio::test]
@@ -103,7 +109,11 @@ async fn test_no_transition_for_already_doing_with_started_at() {
         "buy milk {@task status=todo due=2026-06-01}\n",
         "buy milk {@task status=doing due=2026-06-01 started_at=2026-05-19T08:00}\n",
     );
-    assert_eq!(ts.len(), 0, "No transition expected when started_at already set");
+    assert_eq!(
+        ts.len(),
+        0,
+        "No transition expected when started_at already set"
+    );
 }
 
 #[tokio::test]
@@ -114,7 +124,11 @@ async fn test_no_transition_for_brand_new_task() {
         "some line without a task\n",
         "buy milk {@task status=done due=2026-06-01}\n",
     );
-    assert_eq!(ts.len(), 0, "Brand-new task lines should not trigger auto-edits");
+    assert_eq!(
+        ts.len(),
+        0,
+        "Brand-new task lines should not trigger auto-edits"
+    );
 }
 
 // ─── Edit-generation tests ────────────────────────────────────────────────────
@@ -259,10 +273,7 @@ async fn test_todo_to_done_without_doing_no_time_spent() {
 async fn test_shorthand_done_replaced_with_longform() {
     let _workspace = TestWorkspace::new();
     // Shorthand `-YYYY-MM-DD` (done) transitioning from `!` (todo).
-    let edits = edits_for(
-        "buy milk !2026-06-01\n",
-        "buy milk -2026-06-01\n",
-    );
+    let edits = edits_for("buy milk !2026-06-01\n", "buy milk -2026-06-01\n");
     assert_eq!(edits.len(), 1, "Expected one edit for shorthand todo→done");
     let edit = &edits[0];
     assert_eq!(edit.range.start.line, 0);
@@ -334,7 +345,10 @@ fn test_doing_to_todo_via_keystroke_simulation() {
             .flat_map(|t| generate_edits_for_transition(t, now))
             .collect();
 
-        if transitions.iter().any(|t| matches!(t, TaskTransition::BecameTodo { .. })) {
+        if transitions
+            .iter()
+            .any(|t| matches!(t, TaskTransition::BecameTodo { .. }))
+        {
             became_todo_fired = true;
             clock_out_edits = edits;
         }

--- a/tests/lsp_task_time_tracking.rs
+++ b/tests/lsp_task_time_tracking.rs
@@ -1,0 +1,366 @@
+mod common;
+
+use common::*;
+use patto::lsp::task_edits::{collect_task_snapshots, detect_task_transitions, generate_edits_for_transition};
+use patto::parser::{parse_text, TaskStatus};
+use patto::task::TaskTransition;
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// A fixed "now" used in all tests so assertions on generated text are stable.
+fn fixed_now() -> chrono::NaiveDateTime {
+    chrono::NaiveDate::from_ymd_opt(2026, 5, 19)
+        .unwrap()
+        .and_hms_opt(10, 0, 0)
+        .unwrap()
+}
+
+/// Parse two text snapshots and run the full pipeline, returning all generated
+/// TextEdits.
+fn edits_for(old_text: &str, new_text: &str) -> Vec<tower_lsp::lsp_types::TextEdit> {
+    let old_ast = parse_text(old_text).ast;
+    let new_ast = parse_text(new_text).ast;
+    let old_snaps = collect_task_snapshots(&old_ast);
+    let new_snaps = collect_task_snapshots(&new_ast);
+    let transitions = detect_task_transitions(&new_snaps, &old_snaps);
+    transitions
+        .iter()
+        .flat_map(|t| generate_edits_for_transition(t, fixed_now()))
+        .collect()
+}
+
+/// Parse two text snapshots and return the detected transitions (without
+/// generating edits) — useful for testing detection logic independently.
+fn transitions_for(old_text: &str, new_text: &str) -> Vec<TaskTransition> {
+    let old_ast = parse_text(old_text).ast;
+    let new_ast = parse_text(new_text).ast;
+    let old_snaps = collect_task_snapshots(&old_ast);
+    let new_snaps = collect_task_snapshots(&new_ast);
+    detect_task_transitions(&new_snaps, &old_snaps)
+}
+
+// ─── Detection tests ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_detect_todo_to_done() {
+    let _workspace = TestWorkspace::new();
+    let ts = transitions_for(
+        "buy milk {@task status=todo due=2026-06-01}\n",
+        "buy milk {@task status=done due=2026-06-01}\n",
+    );
+    assert_eq!(ts.len(), 1);
+    assert!(matches!(ts[0], TaskTransition::BecameDone { .. }));
+}
+
+#[tokio::test]
+async fn test_detect_todo_to_doing() {
+    let _workspace = TestWorkspace::new();
+    let ts = transitions_for(
+        "buy milk {@task status=todo due=2026-06-01}\n",
+        "buy milk {@task status=doing due=2026-06-01}\n",
+    );
+    assert_eq!(ts.len(), 1);
+    assert!(matches!(ts[0], TaskTransition::BecameDoing { .. }));
+}
+
+#[tokio::test]
+async fn test_detect_doing_to_todo() {
+    let _workspace = TestWorkspace::new();
+    let ts = transitions_for(
+        "buy milk {@task status=doing due=2026-06-01 started_at=2026-05-19T09:00}\n",
+        "buy milk {@task status=todo due=2026-06-01}\n",
+    );
+    assert_eq!(ts.len(), 1);
+    assert!(matches!(ts[0], TaskTransition::BecameTodo { .. }));
+}
+
+#[tokio::test]
+async fn test_detect_doing_to_done() {
+    let _workspace = TestWorkspace::new();
+    let ts = transitions_for(
+        "buy milk {@task status=doing due=2026-06-01 started_at=2026-05-19T09:00}\n",
+        "buy milk {@task status=done due=2026-06-01}\n",
+    );
+    assert_eq!(ts.len(), 1);
+    assert!(matches!(ts[0], TaskTransition::BecameDone { .. }));
+}
+
+#[tokio::test]
+async fn test_no_transition_for_already_done_with_completed_at() {
+    let _workspace = TestWorkspace::new();
+    // Task already has completed_at — should not produce a second edit.
+    let ts = transitions_for(
+        "buy milk {@task status=todo due=2026-06-01}\n",
+        "buy milk {@task status=done due=2026-06-01 completed_at=2026-05-18T10:00}\n",
+    );
+    assert_eq!(ts.len(), 0, "No transition expected when completed_at already set");
+}
+
+#[tokio::test]
+async fn test_no_transition_for_already_doing_with_started_at() {
+    let _workspace = TestWorkspace::new();
+    // Task already has started_at — should not produce a second clock-in edit.
+    let ts = transitions_for(
+        "buy milk {@task status=todo due=2026-06-01}\n",
+        "buy milk {@task status=doing due=2026-06-01 started_at=2026-05-19T08:00}\n",
+    );
+    assert_eq!(ts.len(), 0, "No transition expected when started_at already set");
+}
+
+#[tokio::test]
+async fn test_no_transition_for_brand_new_task() {
+    let _workspace = TestWorkspace::new();
+    // A task that appears in the new snapshot but not in the old one is skipped.
+    let ts = transitions_for(
+        "some line without a task\n",
+        "buy milk {@task status=done due=2026-06-01}\n",
+    );
+    assert_eq!(ts.len(), 0, "Brand-new task lines should not trigger auto-edits");
+}
+
+// ─── Edit-generation tests ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_clock_in_inserts_started_at() {
+    let _workspace = TestWorkspace::new();
+    let edits = edits_for(
+        "buy milk {@task status=todo due=2026-06-01}\n",
+        "buy milk {@task status=doing due=2026-06-01}\n",
+    );
+    assert_eq!(edits.len(), 1, "Expected one edit for todo→doing");
+    let edit = &edits[0];
+    assert_eq!(edit.range.start.line, 0);
+    assert!(
+        edit.new_text.contains("started_at="),
+        "Edit should contain started_at, got: {}",
+        edit.new_text
+    );
+    assert!(
+        edit.new_text.contains("2026-05-19T10:00"),
+        "started_at should equal fixed_now, got: {}",
+        edit.new_text
+    );
+}
+
+#[tokio::test]
+async fn test_clock_out_to_todo_updates_time_spent() {
+    let _workspace = TestWorkspace::new();
+    // started_at is 1 hour before fixed_now (09:00 → 10:00 = 60 min).
+    // Old snapshot has started_at; new snapshot (user only changed status word) also retains it.
+    let edits = edits_for(
+        "buy milk {@task status=doing due=2026-06-01 started_at=2026-05-19T09:00}\n",
+        "buy milk {@task status=todo due=2026-06-01}\n",
+    );
+    assert_eq!(edits.len(), 1, "Expected one edit for doing→todo");
+    let edit = &edits[0];
+    assert!(
+        edit.new_text.contains("time_spent=1h"),
+        "Edit should accumulate 1 hour of time_spent, got: {}",
+        edit.new_text
+    );
+    assert!(
+        !edit.new_text.contains("started_at="),
+        "started_at should be removed on clock-out, got: {}",
+        edit.new_text
+    );
+}
+
+/// Simulates the real-world nvim case: the user only changed the status word
+/// from `doing` to `todo`, leaving `started_at` intact in the line.
+/// The server must still compute elapsed time from the in-line `started_at`.
+#[tokio::test]
+async fn test_clock_out_to_todo_started_at_retained_in_line() {
+    let _workspace = TestWorkspace::new();
+    // Both old and new snapshots have started_at (user only changed the status word).
+    let edits = edits_for(
+        "buy milk {@task status=doing due=2026-06-01 started_at=2026-05-19T09:00}\n",
+        "buy milk {@task status=todo due=2026-06-01 started_at=2026-05-19T09:00}\n",
+    );
+    assert_eq!(edits.len(), 1, "Expected one edit for doing→todo");
+    let edit = &edits[0];
+    assert!(
+        edit.new_text.contains("time_spent=1h"),
+        "Edit should accumulate 1 hour of time_spent, got: {}",
+        edit.new_text
+    );
+    assert!(
+        !edit.new_text.contains("started_at="),
+        "started_at should be removed on clock-out, got: {}",
+        edit.new_text
+    );
+}
+
+#[tokio::test]
+async fn test_clock_out_to_done_updates_time_spent_and_completed_at() {
+    let _workspace = TestWorkspace::new();
+    // started_at=09:30, fixed_now=10:00 → 30 min elapsed.
+    let edits = edits_for(
+        "buy milk {@task status=doing due=2026-06-01 started_at=2026-05-19T09:30}\n",
+        "buy milk {@task status=done due=2026-06-01}\n",
+    );
+    assert_eq!(edits.len(), 1, "Expected one edit for doing→done");
+    let edit = &edits[0];
+    assert!(
+        edit.new_text.contains("completed_at="),
+        "Edit should set completed_at, got: {}",
+        edit.new_text
+    );
+    assert!(
+        edit.new_text.contains("time_spent=30m"),
+        "Edit should set time_spent=30m, got: {}",
+        edit.new_text
+    );
+    assert!(
+        !edit.new_text.contains("started_at="),
+        "started_at should be removed, got: {}",
+        edit.new_text
+    );
+}
+
+#[tokio::test]
+async fn test_accumulate_time_spent_across_sessions() {
+    let _workspace = TestWorkspace::new();
+    // First session already accumulated 1h, current session is 30 min → total 1h30m.
+    let edits = edits_for(
+        "buy milk {@task status=doing due=2026-06-01 started_at=2026-05-19T09:30 time_spent=1h}\n",
+        "buy milk {@task status=todo due=2026-06-01 time_spent=1h}\n",
+    );
+    assert_eq!(edits.len(), 1);
+    let edit = &edits[0];
+    assert!(
+        edit.new_text.contains("time_spent=1h30m"),
+        "Edit should accumulate to 1h30m, got: {}",
+        edit.new_text
+    );
+}
+
+#[tokio::test]
+async fn test_todo_to_done_without_doing_no_time_spent() {
+    let _workspace = TestWorkspace::new();
+    // Direct todo→done without a doing phase: no time_spent should be added.
+    let edits = edits_for(
+        "buy milk {@task status=todo due=2026-06-01}\n",
+        "buy milk {@task status=done due=2026-06-01}\n",
+    );
+    assert_eq!(edits.len(), 1, "Expected one edit for todo→done");
+    let edit = &edits[0];
+    assert!(
+        edit.new_text.contains("completed_at="),
+        "Edit should set completed_at, got: {}",
+        edit.new_text
+    );
+    assert!(
+        !edit.new_text.contains("time_spent="),
+        "No time_spent should be added without a doing phase, got: {}",
+        edit.new_text
+    );
+}
+
+#[tokio::test]
+async fn test_shorthand_done_replaced_with_longform() {
+    let _workspace = TestWorkspace::new();
+    // Shorthand `-YYYY-MM-DD` (done) transitioning from `!` (todo).
+    let edits = edits_for(
+        "buy milk !2026-06-01\n",
+        "buy milk -2026-06-01\n",
+    );
+    assert_eq!(edits.len(), 1, "Expected one edit for shorthand todo→done");
+    let edit = &edits[0];
+    assert_eq!(edit.range.start.line, 0);
+    assert!(
+        edit.new_text.contains("{@task"),
+        "Shorthand should be replaced with longform block, got: {}",
+        edit.new_text
+    );
+    assert!(
+        edit.new_text.contains("status=done"),
+        "Replacement block should carry status=done, got: {}",
+        edit.new_text
+    );
+    assert!(
+        edit.new_text.contains("completed_at="),
+        "Replacement block should contain completed_at, got: {}",
+        edit.new_text
+    );
+}
+
+/// Simulate the keystroke-by-keystroke `doing` → `todo` transition as nvim
+/// sends it: each character change fires a separate `did_change`.
+///
+/// Intermediate states where `status=` has no value produce no parseable task.
+/// The sticky snapshot map must bridge across those gaps so the final
+/// `doing → todo` transition still has access to the `Doing` state.
+///
+/// We test this by running the pipeline directly, step by step, maintaining
+/// our own sticky map — mirroring exactly what `on_change` does internally.
+#[test]
+fn test_doing_to_todo_via_keystroke_simulation() {
+    use patto::task::Duration;
+    use std::collections::HashMap;
+
+    let now = fixed_now();
+
+    // Simulate the sequence of texts nvim would send
+    let keystrokes: &[&str] = &[
+        // Initial state (from did_open)
+        "buy milk {@task status=doing due=2026-06-01 started_at=2026-05-19T09:00}\n",
+        // User starts deleting "doing"
+        "buy milk {@task status=doin due=2026-06-01 started_at=2026-05-19T09:00}\n",
+        "buy milk {@task status=doi due=2026-06-01 started_at=2026-05-19T09:00}\n",
+        "buy milk {@task status=do due=2026-06-01 started_at=2026-05-19T09:00}\n",
+        "buy milk {@task status=d due=2026-06-01 started_at=2026-05-19T09:00}\n",
+        // status= with no value — task fails to parse entirely
+        "buy milk {@task status= due=2026-06-01 started_at=2026-05-19T09:00}\n",
+        // User types "todo"
+        "buy milk {@task status=t due=2026-06-01 started_at=2026-05-19T09:00}\n",
+        "buy milk {@task status=to due=2026-06-01 started_at=2026-05-19T09:00}\n",
+        "buy milk {@task status=tod due=2026-06-01 started_at=2026-05-19T09:00}\n",
+        "buy milk {@task status=todo due=2026-06-01 started_at=2026-05-19T09:00}\n",
+    ];
+
+    // Sticky map starts empty (no prior state)
+    let mut sticky: HashMap<usize, patto::task::TaskSnapshot> = HashMap::new();
+
+    let mut became_todo_fired = false;
+    let mut clock_out_edits: Vec<tower_lsp::lsp_types::TextEdit> = vec![];
+
+    for text in keystrokes {
+        let ast = parse_text(text);
+        let new_snaps = collect_task_snapshots(&ast.ast);
+
+        // Detect transitions using the current sticky map as old state
+        let transitions = detect_task_transitions(&new_snaps, &sticky);
+        let edits: Vec<_> = transitions
+            .iter()
+            .flat_map(|t| generate_edits_for_transition(t, now))
+            .collect();
+
+        if transitions.iter().any(|t| matches!(t, TaskTransition::BecameTodo { .. })) {
+            became_todo_fired = true;
+            clock_out_edits = edits;
+        }
+
+        // Update sticky: only canonical states overwrite
+        for (row, snap) in &new_snaps {
+            if snap.status_is_canonical {
+                sticky.insert(*row, snap.clone());
+            }
+        }
+    }
+
+    assert!(
+        became_todo_fired,
+        "BecameTodo should have fired during the keystroke sequence"
+    );
+    assert_eq!(clock_out_edits.len(), 1, "Expected one clock-out edit");
+    let edit = &clock_out_edits[0];
+    assert!(
+        edit.new_text.contains("time_spent=1h"),
+        "Clock-out edit should accumulate 1h of time_spent, got: {}",
+        edit.new_text
+    );
+    assert!(
+        !edit.new_text.contains("started_at="),
+        "Clock-out edit should remove started_at, got: {}",
+        edit.new_text
+    );
+}


### PR DESCRIPTION
## Summary

Adds automatic task time tracking to patto: when a task transitions between `todo`/`doing`/`done` statuses, the LSP backend automatically maintains `started_at` and `time_spent` fields inside the `{@task …}` block. All clients display the structured fields cleanly rather than the raw property blob.

## Changes

### Core (Rust)
- **`src/task.rs`** (new): `Duration`, `TaskSnapshot` (with `started_at`, `time_spent`, `status_is_canonical`), `TaskTransition`
- **`src/lsp/task_edits.rs`** (new): full pipeline — `walk_task_lines`, `collect_task_snapshots`, `detect_task_transitions`, `generate_edits_for_transition`
- **`src/lsp/backend.rs`**: `on_change` wired to new pipeline; `task_label()` strips `{@task …}` token; `TaskInformation` extended with `status`, `scheduled`, `completed_at`, `started_at`, `time_spent`; `tasks_review` response includes same fields
- **`src/parser.rs`**: `Property::Task` extended with new fields; `TaskStatus` derives `Eq + Deserialize`; `Deadline::Display` fixed to emit `YYYY-MM-DDThh:mm`

### Neovim / Vim
- **`lua/patto.lua`**: `LspPattoTasks` and `LspPattoTasksReview` location list entries show `[due:DATE] label [XhYm]` / `[DATE] label [XhYm]`
- **`lua/trouble/sources/patto_tasks.lua`** (new): Trouble.nvim source with chip formatters — status icon, due date, ⏱ time spent, ▶ started-at; grouped by deadline bucket
- **`lua/trouble/sources/patto_tasks_review.lua`** (new): Trouble.nvim source for completed tasks; grouped by recency (Today/Yesterday/This Week/…)
- **`settings/vimlsp.vim`**: `s:show_task` and `s:show_tasks_review` updated with same chip format

### VS Code
- **`client/src/extension.ts`**: `taskLabel()` helper; tree view and tasks_review QuickPick both show `[due:DATE] label [XhYm]` / `✓ DATE label ⏱ time`

## Behaviour

| Transition | Effect |
|---|---|
| todo/done → doing | Sets `started_at` to current datetime |
| doing → done | Accumulates elapsed time into `time_spent`, clears `started_at`, sets `completed_at` |
| doing → todo | Accumulates elapsed time into `time_spent`, clears `started_at` |

Status changes are detected on `textDocument/didChange` (no manual commands needed). A `status_is_canonical` flag prevents spurious transitions mid-keystroke.