### PR TITLE
feat: add paused status for intuitive task clock-out

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -136,7 +136,8 @@ function taskLabel(task: any): string {
 	parts.push(task.text as string);
 
 	// status chip (only show non-todo)
-	if (task.status === 'Doing') parts.push('[doing]');
+	if (task.status === 'Doing')  parts.push('[doing]');
+	if (task.status === 'Paused') parts.push('[paused]');
 
 	// time_spent chip
 	const ts = task.time_spent;

--- a/lua/patto.lua
+++ b/lua/patto.lua
@@ -172,6 +172,8 @@ return {
             -- status (only show non-todo)
             if item.status == "Doing" then
               parts[#parts+1] = "[doing]"
+            elseif item.status == "Paused" then
+              parts[#parts+1] = "[paused]"
             end
             -- time_spent
             if type(item.time_spent) == "table" then

--- a/lua/trouble/sources/patto_tasks.lua
+++ b/lua/trouble/sources/patto_tasks.lua
@@ -83,9 +83,10 @@ M.config = {
     -- Status icon: ○ todo  ◑ doing  ✓ done
     task_status = function(ctx)
       local status = (ctx.item.item or {}).status
-      if     status == "Doing" then return { text = "◑ ", hl = "DiagnosticWarn" }
-      elseif status == "Done"  then return { text = "✓ ", hl = "DiagnosticOk"   }
-      else                          return { text = "○ ", hl = "Comment"        }
+      if     status == "Doing"  then return { text = "◑ ", hl = "DiagnosticWarn" }
+      elseif status == "Paused" then return { text = "⏸ ", hl = "DiagnosticInfo" }
+      elseif status == "Done"   then return { text = "✓ ", hl = "DiagnosticOk"   }
+      else                           return { text = "○ ", hl = "Comment"        }
       end
     end,
 

--- a/settings/vimlsp.vim
+++ b/settings/vimlsp.vim
@@ -104,6 +104,8 @@ function! s:show_task(res) abort
         let l:status = get(l:item, 'status', '')
         if l:status ==# 'Doing'
             call add(l:parts, '[doing]')
+        elseif l:status ==# 'Paused'
+            call add(l:parts, '[paused]')
         endif
 
         " time_spent chip

--- a/src/lsp/task_edits.rs
+++ b/src/lsp/task_edits.rs
@@ -569,7 +569,10 @@ mod tests {
         };
         let transitions = detect_task_transitions(&new, &old);
         assert_eq!(transitions.len(), 1);
-        assert!(matches!(transitions[0], TaskTransition::BecamePaused { .. }));
+        assert!(matches!(
+            transitions[0],
+            TaskTransition::BecamePaused { .. }
+        ));
     }
 
     #[test]
@@ -626,8 +629,8 @@ mod tests {
 
     #[test]
     fn doing_to_paused_accumulates_time() {
-        let now = chrono::NaiveDateTime::parse_from_str("2026-05-19T10:30", "%Y-%m-%dT%H:%M")
-            .unwrap();
+        let now =
+            chrono::NaiveDateTime::parse_from_str("2026-05-19T10:30", "%Y-%m-%dT%H:%M").unwrap();
         let old = {
             let mut m = HashMap::new();
             m.insert(
@@ -646,8 +649,18 @@ mod tests {
         let edits = generate_edits_for_transition(&transitions[0], now);
         // Should produce time_spent and clear started_at.
         assert!(!edits.is_empty());
-        let combined = edits.iter().map(|e| e.new_text.as_str()).collect::<Vec<_>>().join(" ");
-        assert!(combined.contains("time_spent=1h30m"), "expected time_spent=1h30m in: {combined}");
-        assert!(!combined.contains("started_at"), "started_at should be removed in: {combined}");
+        let combined = edits
+            .iter()
+            .map(|e| e.new_text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            combined.contains("time_spent=1h30m"),
+            "expected time_spent=1h30m in: {combined}"
+        );
+        assert!(
+            !combined.contains("started_at"),
+            "started_at should be removed in: {combined}"
+        );
     }
 }

--- a/src/lsp/task_edits.rs
+++ b/src/lsp/task_edits.rs
@@ -107,6 +107,10 @@ pub fn collect_task_snapshots(root: &AstNode) -> HashMap<usize, TaskSnapshot> {
 /// - `* → Done` without a `completed_at` already set  → `BecameDone`
 /// - `* → Doing` without a `started_at` already set   → `BecameDoing`
 /// - `Doing → Todo`                                    → `BecameTodo`  (clock-out)
+/// - `Doing → Paused`                                  → `BecamePaused` (explicit pause)
+///
+/// Note: only one transition is emitted per row per call. The match arms are
+/// ordered so that the most specific / highest-priority rule wins first.
 pub fn detect_task_transitions(
     new_snapshots: &HashMap<usize, TaskSnapshot>,
     old_snapshots: &HashMap<usize, TaskSnapshot>,
@@ -127,9 +131,14 @@ pub fn detect_task_transitions(
             continue;
         }
 
+        // Guard: skip if old == new status (no actual change).
+        if new.status == old.status {
+            continue;
+        }
+
         match (&new.status, &old.status) {
             // ── Any → Done ─────────────────────────────────────────────────
-            (TaskStatus::Done, prev) if *prev != TaskStatus::Done => {
+            (TaskStatus::Done, _) => {
                 // Only inject completed_at if it is not already present.
                 if new.completed_at.is_none() {
                     transitions.push(TaskTransition::BecameDone {
@@ -140,7 +149,7 @@ pub fn detect_task_transitions(
             }
 
             // ── Any → Doing ────────────────────────────────────────────────
-            (TaskStatus::Doing, prev) if *prev != TaskStatus::Doing => {
+            (TaskStatus::Doing, _) => {
                 // Only inject started_at if it is not already present.
                 if new.started_at.is_none() {
                     transitions.push(TaskTransition::BecameDoing {
@@ -148,6 +157,14 @@ pub fn detect_task_transitions(
                         new: new.clone(),
                     });
                 }
+            }
+
+            // ── Doing → Paused ─────────────────────────────────────────────
+            (TaskStatus::Paused, TaskStatus::Doing) => {
+                transitions.push(TaskTransition::BecamePaused {
+                    old: old.clone(),
+                    new: new.clone(),
+                });
             }
 
             // ── Doing → Todo ───────────────────────────────────────────────
@@ -158,6 +175,7 @@ pub fn detect_task_transitions(
                 });
             }
 
+            // ── All other transitions (e.g. Paused→Todo, Done→Todo, etc.) ─
             _ => {}
         }
     }
@@ -219,7 +237,7 @@ pub fn generate_edits_for_transition(
         }
 
         // ── BecameTodo (clock-out without Done) ───────────────────────────
-        TaskTransition::BecameTodo { old, new } => {
+        TaskTransition::BecameTodo { old, new } | TaskTransition::BecamePaused { old, new } => {
             // Prefer started_at from the new snapshot (it may still be present
             // in the line text if the user only changed the status word).
             // Fall back to old snapshot in case the user also deleted it.
@@ -342,6 +360,7 @@ fn build_longform_full_rewrite(
                 status = match value.as_str() {
                     "todo" => TaskStatus::Todo,
                     "doing" => TaskStatus::Doing,
+                    "paused" => TaskStatus::Paused,
                     "done" => TaskStatus::Done,
                     _ => status,
                 };
@@ -381,6 +400,7 @@ fn build_longform_full_rewrite(
     let status_str = match status {
         TaskStatus::Todo => "todo",
         TaskStatus::Doing => "doing",
+        TaskStatus::Paused => "paused",
         TaskStatus::Done => "done",
     };
 
@@ -528,5 +548,106 @@ mod tests {
         };
         let transitions = detect_task_transitions(&new, &old);
         assert_eq!(transitions.len(), 0);
+    }
+
+    // ── Paused status ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn detect_doing_to_paused() {
+        let old = {
+            let mut m = HashMap::new();
+            m.insert(
+                0,
+                make_snapshot(0, TaskStatus::Doing, Some("2026-05-19T09:00")),
+            );
+            m
+        };
+        let new = {
+            let mut m = HashMap::new();
+            m.insert(0, make_snapshot(0, TaskStatus::Paused, None));
+            m
+        };
+        let transitions = detect_task_transitions(&new, &old);
+        assert_eq!(transitions.len(), 1);
+        assert!(matches!(transitions[0], TaskTransition::BecamePaused { .. }));
+    }
+
+    #[test]
+    fn detect_paused_to_doing() {
+        let old = {
+            let mut m = HashMap::new();
+            m.insert(0, make_snapshot(0, TaskStatus::Paused, None));
+            m
+        };
+        let new = {
+            let mut m = HashMap::new();
+            m.insert(0, make_snapshot(0, TaskStatus::Doing, None));
+            m
+        };
+        let transitions = detect_task_transitions(&new, &old);
+        assert_eq!(transitions.len(), 1);
+        assert!(matches!(transitions[0], TaskTransition::BecameDoing { .. }));
+    }
+
+    #[test]
+    fn no_transition_paused_to_todo() {
+        // Paused → Todo: time already accumulated; nothing to do.
+        let old = {
+            let mut m = HashMap::new();
+            m.insert(0, make_snapshot(0, TaskStatus::Paused, None));
+            m
+        };
+        let new = {
+            let mut m = HashMap::new();
+            m.insert(0, make_snapshot(0, TaskStatus::Todo, None));
+            m
+        };
+        let transitions = detect_task_transitions(&new, &old);
+        assert_eq!(transitions.len(), 0);
+    }
+
+    #[test]
+    fn no_transition_todo_to_paused() {
+        // Todo → Paused without ever clocking in: no started_at to flush.
+        let old = {
+            let mut m = HashMap::new();
+            m.insert(0, make_snapshot(0, TaskStatus::Todo, None));
+            m
+        };
+        let new = {
+            let mut m = HashMap::new();
+            m.insert(0, make_snapshot(0, TaskStatus::Paused, None));
+            m
+        };
+        let transitions = detect_task_transitions(&new, &old);
+        // No BecamePaused because old was not Doing.
+        assert_eq!(transitions.len(), 0);
+    }
+
+    #[test]
+    fn doing_to_paused_accumulates_time() {
+        let now = chrono::NaiveDateTime::parse_from_str("2026-05-19T10:30", "%Y-%m-%dT%H:%M")
+            .unwrap();
+        let old = {
+            let mut m = HashMap::new();
+            m.insert(
+                0,
+                make_snapshot(0, TaskStatus::Doing, Some("2026-05-19T09:00")),
+            );
+            m
+        };
+        let new = {
+            let mut m = HashMap::new();
+            m.insert(0, make_snapshot(0, TaskStatus::Paused, None));
+            m
+        };
+        let transitions = detect_task_transitions(&new, &old);
+        assert_eq!(transitions.len(), 1);
+        let edits = generate_edits_for_transition(&transitions[0], now);
+        // Should produce time_spent and clear started_at.
+        assert!(!edits.is_empty());
+        let combined = edits.iter().map(|e| e.new_text.as_str()).collect::<Vec<_>>().join(" ");
+        assert!(combined.contains("time_spent=1h30m"), "expected time_spent=1h30m in: {combined}");
+        assert!(!combined.contains("started_at"), "started_at should be removed in: {combined}");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1700,23 +1700,23 @@ fn transform_property(
                             Rule::property_keyword_value => {
                                 let value = kv.as_str();
                                 if current_key == "status" {
-                                     status = match value {
-                                         "todo" => {
-                                             status_is_canonical = true;
-                                             TaskStatus::Todo
-                                         }
-                                         "doing" => {
-                                             status_is_canonical = true;
-                                             TaskStatus::Doing
-                                         }
-                                         "paused" => {
-                                             status_is_canonical = true;
-                                             TaskStatus::Paused
-                                         }
-                                         "done" => {
-                                             status_is_canonical = true;
-                                             TaskStatus::Done
-                                         }
+                                    status = match value {
+                                        "todo" => {
+                                            status_is_canonical = true;
+                                            TaskStatus::Todo
+                                        }
+                                        "doing" => {
+                                            status_is_canonical = true;
+                                            TaskStatus::Doing
+                                        }
+                                        "paused" => {
+                                            status_is_canonical = true;
+                                            TaskStatus::Paused
+                                        }
+                                        "done" => {
+                                            status_is_canonical = true;
+                                            TaskStatus::Done
+                                        }
                                         _ => {
                                             log::warn!(
                                                 "Unknown task status: '{}', interpreted as 'todo'",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -219,6 +219,7 @@ impl Ord for Deadline {
 pub enum TaskStatus {
     Todo,
     Doing,
+    Paused,
     Done,
 }
 
@@ -1663,6 +1664,10 @@ fn transform_property(
                                             status_is_canonical = true;
                                             TaskStatus::Doing
                                         }
+                                        "paused" => {
+                                            status_is_canonical = true;
+                                            TaskStatus::Paused
+                                        }
                                         "done" => {
                                             status_is_canonical = true;
                                             TaskStatus::Done
@@ -1695,19 +1700,23 @@ fn transform_property(
                             Rule::property_keyword_value => {
                                 let value = kv.as_str();
                                 if current_key == "status" {
-                                    status = match value {
-                                        "todo" => {
-                                            status_is_canonical = true;
-                                            TaskStatus::Todo
-                                        }
-                                        "doing" => {
-                                            status_is_canonical = true;
-                                            TaskStatus::Doing
-                                        }
-                                        "done" => {
-                                            status_is_canonical = true;
-                                            TaskStatus::Done
-                                        }
+                                     status = match value {
+                                         "todo" => {
+                                             status_is_canonical = true;
+                                             TaskStatus::Todo
+                                         }
+                                         "doing" => {
+                                             status_is_canonical = true;
+                                             TaskStatus::Doing
+                                         }
+                                         "paused" => {
+                                             status_is_canonical = true;
+                                             TaskStatus::Paused
+                                         }
+                                         "done" => {
+                                             status_is_canonical = true;
+                                             TaskStatus::Done
+                                         }
                                         _ => {
                                             log::warn!(
                                                 "Unknown task status: '{}', interpreted as 'todo'",

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1124,6 +1124,7 @@ impl PattoRenderer {
                     let status_str = match status {
                         TaskStatus::Todo => "todo",
                         TaskStatus::Doing => "doing",
+                        TaskStatus::Paused => "paused",
                         TaskStatus::Done => "done",
                     };
                     let due_str = due.to_string();
@@ -1184,6 +1185,7 @@ impl PattoRenderer {
                     let status_str = match status {
                         TaskStatus::Todo => "todo",
                         TaskStatus::Doing => "doing",
+                        TaskStatus::Paused => "paused",
                         TaskStatus::Done => "done",
                     };
                     let due_str = due.to_string();

--- a/src/task.rs
+++ b/src/task.rs
@@ -169,6 +169,11 @@ pub enum TaskTransition {
         old: TaskSnapshot,
         new: TaskSnapshot,
     },
+    /// Doing → Paused (explicit pause; same clock-out logic as BecameTodo).
+    BecamePaused {
+        old: TaskSnapshot,
+        new: TaskSnapshot,
+    },
 }
 
 impl TaskTransition {
@@ -178,6 +183,7 @@ impl TaskTransition {
             TaskTransition::BecameDone { new, .. } => new.row,
             TaskTransition::BecameDoing { new, .. } => new.row,
             TaskTransition::BecameTodo { new, .. } => new.row,
+            TaskTransition::BecamePaused { new, .. } => new.row,
         }
     }
 
@@ -186,6 +192,7 @@ impl TaskTransition {
             TaskTransition::BecameDone { new, .. } => new,
             TaskTransition::BecameDoing { new, .. } => new,
             TaskTransition::BecameTodo { new, .. } => new,
+            TaskTransition::BecamePaused { new, .. } => new,
         }
     }
 
@@ -194,6 +201,7 @@ impl TaskTransition {
             TaskTransition::BecameDone { old, .. } => old,
             TaskTransition::BecameDoing { old, .. } => old,
             TaskTransition::BecameTodo { old, .. } => old,
+            TaskTransition::BecamePaused { old, .. } => old,
         }
     }
 }

--- a/src/tui_renderer.rs
+++ b/src/tui_renderer.rs
@@ -232,6 +232,7 @@ fn render_node(
                 let (icon, color) = match status {
                     TaskStatus::Done => ("✓ ", Color::Green),
                     TaskStatus::Doing => ("◑ ", Color::Yellow),
+                    TaskStatus::Paused => ("⏸ ", Color::Cyan),
                     _ => ("○ ", Color::White),
                 };
                 prefix_spans.push(Span::styled(icon.to_string(), Style::default().fg(color)));


### PR DESCRIPTION
## Summary

Adds a dedicated `status=paused` value so users can explicitly pause a task instead of having to reset it to `todo` (which felt semantically wrong and discarded clock context).

## Workflow

```
{@task status=todo due=2026-06-01}   →   set to doing   →   set to paused   →   set to doing   →   set to done
```

| Transition | Effect |
|---|---|
| `doing → paused` | Accumulates elapsed time into `time_spent`, clears `started_at`, writes `status=paused` |
| `paused → doing` | Sets fresh `started_at = now` (clock resumes) |
| `paused → todo` | No-op — time already accumulated safely |
| `todo → paused` | No-op — no `started_at` to flush (old-status guard) |
| `done → paused` | No-op — same guard |
| All other transitions | Unchanged from before |

## Changes

- **`src/parser.rs`**: `TaskStatus::Paused` variant + `"paused"` in both longform parse arms (canonical)
- **`src/task.rs`**: `TaskTransition::BecamePaused { old, new }` + all match arms
- **`src/lsp/task_edits.rs`**:
  - Explicit same-status guard (`new == old → skip`) prevents any duplicate transitions
  - `Doing → Paused` emits `BecamePaused`; `Paused → Todo` falls through to `_ => {}`
  - `BecamePaused` shares edit-generation logic with `BecameTodo`
  - `status_to_str` / `str_to_status`: `"paused"` added
- **`src/renderer.rs`**: both longform render sites updated
- **`src/tui_renderer.rs`**: `⏸` with `Color::Cyan`
- **Clients**: `⏸` icon (Trouble.nvim), `[paused]` chip (location lists / VS Code tree view)

## Tests

5 new unit tests in `src/lsp/task_edits.rs`:
- `detect_doing_to_paused`
- `detect_paused_to_doing`
- `no_transition_paused_to_todo`
- `no_transition_todo_to_paused`
- `doing_to_paused_accumulates_time` (verifies 1h30m elapsed, `started_at` cleared)