### PR TITLE
feat: add LSP folding range support

### DIFF
--- a/after/ftplugin/patto.vim
+++ b/after/ftplugin/patto.vim
@@ -8,10 +8,3 @@ setlocal noexpandtab
 setlocal nowrap
 setlocal commentstring=[-\ %s]
 
-" LSP-based folding (requires Neovim 0.10+ with patto-lsp running)
-if has('nvim-0.10')
-  setlocal foldmethod=expr
-  setlocal foldexpr=v:lua.vim.lsp.foldexpr()
-  setlocal foldtext=v:lua.require('patto.foldtext').foldtext()
-  setlocal foldlevel=99
-endif

--- a/after/ftplugin/patto.vim
+++ b/after/ftplugin/patto.vim
@@ -7,3 +7,11 @@ setlocal noexpandtab
 " see https://github.com/vim/vim/pull/10442
 setlocal nowrap
 setlocal commentstring=[-\ %s]
+
+" LSP-based folding (requires Neovim 0.10+ with patto-lsp running)
+if has('nvim-0.10')
+  setlocal foldmethod=expr
+  setlocal foldexpr=v:lua.vim.lsp.foldexpr()
+  setlocal foldtext=v:lua.require('patto.foldtext').foldtext()
+  setlocal foldlevel=99
+endif

--- a/lua/patto.lua
+++ b/lua/patto.lua
@@ -133,6 +133,12 @@ return {
   root_markers = {'.git'},
   capabilities = {
     offsetEncoding = { 'utf-8' },
+    textDocument = {
+      foldingRange = {
+        dynamicRegistration = false,
+        lineFoldingOnly = true,
+      },
+    },
   },
   -- Default settings (can be overridden in user config)
   -- To override: vim.lsp.config('patto_lsp', { settings = { patto = { markdown = { defaultFlavor = 'obsidian' } } } })

--- a/lua/patto.lua
+++ b/lua/patto.lua
@@ -149,7 +149,24 @@ return {
       },
     },
   },
+  -- To Enable LSP-based folding: vim.lsp.config('patto_lsp', { lsp_folding = true })
+  lsp_folding = false,
   on_attach = function(client, bufnr)
+    if client.config.lsp_folding and vim.fn.has('nvim-0.10') == 1 then
+      local function set_fold_options()
+        vim.wo.foldmethod = 'expr'
+        vim.wo.foldexpr = 'v:lua.vim.lsp.foldexpr()'
+        vim.wo.foldtext = "v:lua.require('patto.foldtext').foldtext()"
+        vim.wo.foldlevel = 99
+      end
+      set_fold_options()
+      local fold_augroup = vim.api.nvim_create_augroup('patto_lsp_fold', { clear = false })
+      vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWinEnter' }, {
+        group = fold_augroup,
+        buffer = bufnr,
+        callback = set_fold_options,
+      })
+    end
     vim.api.nvim_buf_create_user_command(bufnr, 'LspPattoTasks', function()
       vim.lsp.buf_request_all(0, 'workspace/executeCommand', {
         command = 'experimental/aggregate_tasks',

--- a/lua/patto/foldtext.lua
+++ b/lua/patto/foldtext.lua
@@ -1,0 +1,19 @@
+local M = {}
+
+--- Custom foldtext for patto buffers.
+--- Format: <indent><trimmed first line>  <N lines folded>
+---
+--- Tabs in foldtext are replaced with a single space by Neovim, so we expand
+--- leading tabs manually to spaces using the buffer's tabstop setting so that
+--- the visible text does not move when a fold is opened or closed.
+function M.foldtext()
+  local line = vim.fn.getline(vim.v.foldstart)
+  local tabs = #(line:match('^\t*'))
+  local text = vim.fn.trim(line)
+  local n = vim.v.foldend - vim.v.foldstart
+  local ts = vim.bo.tabstop or 4
+  local indent = string.rep(' ', tabs * ts)
+  return indent .. text .. '  +-- ' .. n .. ' lines folded'
+end
+
+return M

--- a/settings/vimlsp.vim
+++ b/settings/vimlsp.vim
@@ -42,6 +42,14 @@ function! s:is_port_open(host, port) abort
 endfunction
 
 function! s:on_lsp_buffer_enabled() abort
+    " LSP-based folding (requires vim-lsp)
+    " To enable: let g:patto_lsp_folding = 1
+    if get(g:, 'patto_lsp_folding', 0)
+        setlocal foldmethod=expr
+        setlocal foldexpr=lsp#ui#vim#folding#foldexpr()
+        setlocal foldlevel=99
+    endif
+
     command! -buffer LspPattoTasks          call <SID>patto_tasks()
     command! -buffer LspPattoScanWorkspace  call <SID>patto_scan_workspace()
     command! -buffer LspPattoSnapshotPapers call <SID>patto_snapshot_papers()

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -975,6 +975,7 @@ impl LanguageServer for Backend {
                     prepare_provider: Some(true),
                     work_done_progress_options: Default::default(),
                 })),
+                folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
                 ..ServerCapabilities::default()
             },
             ..Default::default()
@@ -1923,6 +1924,118 @@ impl LanguageServer for Backend {
         }
 
         Ok(rename_result)
+    }
+
+    async fn folding_range(&self, params: FoldingRangeParams) -> Result<Option<Vec<FoldingRange>>> {
+        let uri = Repository::normalize_url_percent_encoding(&params.text_document.uri);
+
+        let result = || -> Option<Vec<FoldingRange>> {
+            let repo_lock = self.repository.lock().unwrap();
+            let repo = repo_lock.as_ref()?;
+            let ast = repo.ast_map.get(&uri)?;
+            Some(collect_folding_ranges(ast.value()))
+        }();
+
+        Ok(result)
+    }
+}
+
+/// Recursively find the maximum row number in a node's subtree.
+/// Recurses into both `children` (nested lines / block content) and
+/// `contents` (inline nodes — needed because block command nodes like
+/// `Code`/`Math`/`Quote`/`Table` are stored as *contents* of their
+/// parent `Line`, while their own content lines are *children*).
+fn last_row_of(node: &AstNode) -> usize {
+    let mut max = node.location().row;
+
+    for child in node.value().children.lock().unwrap().iter() {
+        let child_row = last_row_of(child);
+        if child_row > max {
+            max = child_row;
+        }
+    }
+
+    for content in node.value().contents.lock().unwrap().iter() {
+        let content_row = last_row_of(content);
+        if content_row > max {
+            max = content_row;
+        }
+    }
+
+    max
+}
+
+/// Collect LSP `FoldingRange`s from the parsed AST of a patto document.
+///
+/// Fold sources:
+/// - `Line` nodes with at least one child (indentation-based hierarchy)
+/// - `Code { inline: false }`, `Math { inline: false }`, `Quote`, `Table`
+///   block header nodes with at least one child  (kind = Region)
+/// - `QuoteContent` nodes with children (nested quote indentation)
+fn collect_folding_ranges(root: &AstNode) -> Vec<FoldingRange> {
+    let mut ranges = Vec::new();
+    // The Dummy root has no location; iterate its children directly
+    let children = root.value().children.lock().unwrap().clone();
+    for child in children.iter() {
+        collect_folding_ranges_node(child, &mut ranges);
+    }
+    ranges
+}
+
+fn collect_folding_ranges_node(node: &AstNode, ranges: &mut Vec<FoldingRange>) {
+    let start_row = node.location().row;
+
+    // Determine whether/what kind of fold to emit for this node
+    let fold_kind: Option<Option<FoldingRangeKind>> = match node.kind() {
+        AstNodeKind::Line { .. } => Some(None),
+        AstNodeKind::Code { inline, .. } => {
+            if *inline {
+                None // inline code — no fold, but still recurse
+            } else {
+                Some(Some(FoldingRangeKind::Region))
+            }
+        }
+        AstNodeKind::Math { inline } => {
+            if *inline {
+                None
+            } else {
+                Some(Some(FoldingRangeKind::Region))
+            }
+        }
+        AstNodeKind::Quote => Some(Some(FoldingRangeKind::Region)),
+        AstNodeKind::Table { .. } => Some(Some(FoldingRangeKind::Region)),
+        AstNodeKind::QuoteContent { .. } => Some(None),
+        // All other node types are not fold containers
+        _ => None,
+    };
+
+    // Recurse into children and contents (depth-first, so inner folds are added first)
+    {
+        let children = node.value().children.lock().unwrap().clone();
+        for child in children.iter() {
+            collect_folding_ranges_node(child, ranges);
+        }
+    }
+    {
+        let contents = node.value().contents.lock().unwrap().clone();
+        for content in contents.iter() {
+            collect_folding_ranges_node(content, ranges);
+        }
+    }
+
+    // Only emit a fold range if this node type is a fold container
+    if let Some(kind) = fold_kind {
+        let end_row = last_row_of(node);
+        if end_row > start_row {
+            ranges.push(FoldingRange {
+                start_line: start_row as u32,
+                start_character: None,
+                end_line: end_row as u32,
+                end_character: None,
+                kind,
+                collapsed_text: None,
+            });
+        }
     }
 }
 

--- a/tests/common/in_process_client.rs
+++ b/tests/common/in_process_client.rs
@@ -245,6 +245,16 @@ impl InProcessLspClient {
             .flatten()
     }
 
+    /// Get folding ranges for a document
+    pub async fn folding_range(&mut self, uri: Url) -> Option<Vec<FoldingRange>> {
+        let params = FoldingRangeParams {
+            text_document: TextDocumentIdentifier { uri },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        };
+        self.backend.folding_range(params).await.ok().flatten()
+    }
+
     /// Aggregate tasks (Patto-specific)
     pub async fn aggregate_tasks(&mut self) -> Option<Option<serde_json::Value>> {
         self.execute_command("experimental/aggregate_tasks", vec![])

--- a/tests/lsp_folding_range.rs
+++ b/tests/lsp_folding_range.rs
@@ -1,0 +1,201 @@
+mod common;
+
+use common::*;
+use tower_lsp::lsp_types::FoldingRangeKind;
+
+// ---------------------------------------------------------------------------
+// Helper: sort ranges for deterministic assertions
+// ---------------------------------------------------------------------------
+fn sorted(
+    mut ranges: Vec<tower_lsp::lsp_types::FoldingRange>,
+) -> Vec<tower_lsp::lsp_types::FoldingRange> {
+    ranges.sort_by_key(|r| (r.start_line, r.end_line));
+    ranges
+}
+
+// ---------------------------------------------------------------------------
+// Basic indentation folding
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn test_fold_indent_basic() {
+    // Line 0: top-level parent
+    //   Line 1: child (indent 1)
+    //   Line 2: child (indent 1)
+    let content = "parent\n\tchild1\n\tchild2\n";
+
+    let mut workspace = TestWorkspace::new();
+    workspace.create_file("note.pn", content);
+
+    let mut client = InProcessLspClient::new(&workspace).await;
+    let uri = workspace.get_uri("note.pn");
+    client.did_open(uri.clone(), content.to_string()).await;
+
+    let ranges = client
+        .folding_range(uri)
+        .await
+        .expect("folding_range returned None");
+    let ranges = sorted(ranges);
+
+    // The parent line (row 0) should fold over rows 0–2
+    assert!(
+        ranges.iter().any(|r| r.start_line == 0 && r.end_line == 2),
+        "Expected fold from line 0 to line 2; got: {:?}",
+        ranges
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Nested indentation folding
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn test_fold_indent_nested() {
+    // row 0: A
+    //   row 1: B (child of A)
+    //     row 2: C (child of B)
+    //     row 3: D (child of B)
+    //   row 4: E (child of A)
+    let content = "A\n\tB\n\t\tC\n\t\tD\n\tE\n";
+
+    let mut workspace = TestWorkspace::new();
+    workspace.create_file("note.pn", content);
+
+    let mut client = InProcessLspClient::new(&workspace).await;
+    let uri = workspace.get_uri("note.pn");
+    client.did_open(uri.clone(), content.to_string()).await;
+
+    let ranges = client
+        .folding_range(uri)
+        .await
+        .expect("folding_range returned None");
+    let ranges = sorted(ranges);
+
+    // A folds over rows 0–4
+    assert!(
+        ranges.iter().any(|r| r.start_line == 0 && r.end_line == 4),
+        "Expected fold A: 0–4; got: {:?}",
+        ranges
+    );
+    // B folds over rows 1–3
+    assert!(
+        ranges.iter().any(|r| r.start_line == 1 && r.end_line == 3),
+        "Expected fold B: 1–3; got: {:?}",
+        ranges
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Code block folding
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn test_fold_code_block() {
+    // row 0: intro line
+    // row 1: [@code rust]
+    //   row 2: fn main() {}
+    //   row 3: // end
+    // row 4: outro line
+    let content = "intro\n[@code rust]\n\tfn main() {}\n\t// end\noutro\n";
+
+    let mut workspace = TestWorkspace::new();
+    workspace.create_file("note.pn", content);
+
+    let mut client = InProcessLspClient::new(&workspace).await;
+    let uri = workspace.get_uri("note.pn");
+    client.did_open(uri.clone(), content.to_string()).await;
+
+    let ranges = client
+        .folding_range(uri)
+        .await
+        .expect("folding_range returned None");
+
+    // Code block: rows 1–3, kind = Region
+    assert!(
+        ranges.iter().any(|r| {
+            r.start_line == 1 && r.end_line == 3 && r.kind == Some(FoldingRangeKind::Region)
+        }),
+        "Expected code block fold 1–3 (Region); got: {:?}",
+        ranges
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Quote block folding
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn test_fold_quote_block() {
+    // row 0: [@quote]
+    //   row 1: first quoted line
+    //   row 2: second quoted line
+    // row 3: back to normal
+    let content = "[@quote]\n\tquote line 1\n\tquote line 2\nnormal\n";
+
+    let mut workspace = TestWorkspace::new();
+    workspace.create_file("note.pn", content);
+
+    let mut client = InProcessLspClient::new(&workspace).await;
+    let uri = workspace.get_uri("note.pn");
+    client.did_open(uri.clone(), content.to_string()).await;
+
+    let ranges = client
+        .folding_range(uri)
+        .await
+        .expect("folding_range returned None");
+
+    assert!(
+        ranges.iter().any(|r| {
+            r.start_line == 0 && r.end_line == 2 && r.kind == Some(FoldingRangeKind::Region)
+        }),
+        "Expected quote block fold 0–2 (Region); got: {:?}",
+        ranges
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Math block folding
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn test_fold_math_block() {
+    let content = "[@math]\n\tx^2 + y^2 = z^2\n\t\\frac{1}{2}\ntext after\n";
+
+    let mut workspace = TestWorkspace::new();
+    workspace.create_file("note.pn", content);
+
+    let mut client = InProcessLspClient::new(&workspace).await;
+    let uri = workspace.get_uri("note.pn");
+    client.did_open(uri.clone(), content.to_string()).await;
+
+    let ranges = client
+        .folding_range(uri)
+        .await
+        .expect("folding_range returned None");
+
+    assert!(
+        ranges.iter().any(|r| {
+            r.start_line == 0 && r.end_line == 2 && r.kind == Some(FoldingRangeKind::Region)
+        }),
+        "Expected math block fold 0–2 (Region); got: {:?}",
+        ranges
+    );
+}
+
+// ---------------------------------------------------------------------------
+// No folds for flat single-level documents
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn test_fold_flat_no_ranges() {
+    let content = "line one\nline two\nline three\n";
+
+    let mut workspace = TestWorkspace::new();
+    workspace.create_file("note.pn", content);
+
+    let mut client = InProcessLspClient::new(&workspace).await;
+    let uri = workspace.get_uri("note.pn");
+    client.did_open(uri.clone(), content.to_string()).await;
+
+    let ranges = client.folding_range(uri).await.unwrap_or_default();
+
+    assert!(
+        ranges.is_empty(),
+        "Expected no folds for flat document; got: {:?}",
+        ranges
+    );
+}


### PR DESCRIPTION
## Summary

Implements `textDocument/foldingRange` LSP support end-to-end.

## Backend (Rust)

- Register `foldingRangeProvider` capability in `initialize()`
- Implement `folding_range()` handler on `Backend`
- `collect_folding_ranges()` walks the AST and emits folds for:
  - `Line` nodes with children → indentation-based hierarchy folds
  - `Code` / `Math` (non-inline) / `Quote` / `Table` block headers → `Region` kind folds
  - `QuoteContent` nodes with children → nested quote indentation folds
- `last_row_of()` recurses into both `children` and `contents` to correctly compute end rows (block command nodes like `Code` are stored as *contents* of their parent `Line`, while content lines are *children* of the command node)

## Neovim client (Lua / Vimscript)

- `lua/patto.lua`: advertise `textDocument.foldingRange` capability with `lineFoldingOnly: true`
- `after/ftplugin/patto.vim`: enable `foldmethod=expr` with `vim.lsp.foldexpr()` on Neovim 0.10+; `foldlevel=99` so all folds start open
- `lua/patto/foldtext.lua`: custom foldtext that preserves visual indentation — Neovim collapses tabs in foldtext to single spaces, so leading tabs are expanded to `tabstop`-width spaces manually. Format: `<indent><text>  N lines folded`

## Tests

- `tests/lsp_folding_range.rs`: 6 integration tests covering indentation folds, nested folds, code blocks, quote blocks, math blocks, and flat (no-fold) documents
- `tests/common/in_process_client.rs`: added `folding_range()` helper