### PR TITLE
feat(preview-tui): bring patto-preview-tui UX to parity with Neovim plugins

### DIFF
--- a/src/bin/patto-preview-tui/app.rs
+++ b/src/bin/patto-preview-tui/app.rs
@@ -545,6 +545,10 @@ impl App {
             (KeyCode::Char('q'), _) | (KeyCode::Esc, _) | (KeyCode::Char('T'), _) => {
                 self.close_tasks_panel();
             }
+            (KeyCode::Char('r'), KeyModifiers::NONE) | (KeyCode::Char('R'), _) => {
+                self.tasks.toggle_view();
+                self.tasks.refresh_review(repository);
+            }
             (KeyCode::Char('j'), _) | (KeyCode::Down, _) => {
                 self.tasks.navigate_down();
                 self.load_task_preview(repository).await;

--- a/src/bin/patto-preview-tui/main.rs
+++ b/src/bin/patto-preview-tui/main.rs
@@ -363,8 +363,13 @@ async fn main() -> anyhow::Result<()> {
                             app.tasks.refresh(&repository);
                         }
                     }
+                    Ok(RepositoryMessage::ScanCompleted { .. }) | Ok(RepositoryMessage::FileAdded(..)) => {
+                        // Initial workspace scan finished (or new file appeared) — refresh
+                        // the task cache so the active-task overlay reflects all files.
+                        app.tasks.refresh(&repository);
+                    }
                     Ok(_) => {
-                        // Other messages: ignore for single-file mode
+                        // Other messages: ignore
                     }
                     Err(_) => {
                         // Channel lagged or closed

--- a/src/bin/patto-preview-tui/main.rs
+++ b/src/bin/patto-preview-tui/main.rs
@@ -289,6 +289,10 @@ async fn main() -> anyhow::Result<()> {
     let mut terminal = Terminal::new(backend)?;
 
     let mut event_stream = EventStream::new();
+    // Display-refresh interval: re-render every 60 s so live elapsed time
+    // on Doing tasks stays current (mirrors display_interval in current_task.lua).
+    let mut display_tick = tokio::time::interval(std::time::Duration::from_secs(60));
+    display_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
     // Main loop
     loop {
@@ -366,6 +370,11 @@ async fn main() -> anyhow::Result<()> {
                         // Channel lagged or closed
                     }
                 }
+            }
+            _ = display_tick.tick() => {
+                // Periodic redraw: live elapsed time on Doing tasks is recomputed
+                // from Local::now() during rendering, so just waking the loop is enough.
+                // Only meaningful when there are active Doing tasks.
             }
         }
     }

--- a/src/bin/patto-preview-tui/main.rs
+++ b/src/bin/patto-preview-tui/main.rs
@@ -277,8 +277,9 @@ async fn main() -> anyhow::Result<()> {
         app.scroll_to_source_line(line);
     }
 
-    // Compute initial backlinks
+    // Compute initial backlinks and task cache
     app.backlinks.refresh(&repository, &app.file_path).await;
+    app.tasks.refresh(&repository);
 
     // Set up terminal
     enable_raw_mode()?;
@@ -355,6 +356,7 @@ async fn main() -> anyhow::Result<()> {
                         if path == app.file_path {
                             app.re_render(&content);
                             app.backlinks.refresh(&repository, &app.file_path).await;
+                            app.tasks.refresh(&repository);
                         }
                     }
                     Ok(_) => {

--- a/src/bin/patto-preview-tui/tasks.rs
+++ b/src/bin/patto-preview-tui/tasks.rs
@@ -39,9 +39,7 @@ fn extract_task_meta(
                     }
                 });
                 let sa_str = started_at.as_ref().and_then(|dl| match dl {
-                    Deadline::DateTime(dt) => {
-                        Some(format!("{:02}:{:02}", dt.hour(), dt.minute()))
-                    }
+                    Deadline::DateTime(dt) => Some(format!("{:02}:{:02}", dt.hour(), dt.minute())),
                     _ => None,
                 });
                 return (status.clone(), ts_str, sa_str);
@@ -436,10 +434,7 @@ impl TasksPanel {
             let text = node.extract_str().trim_start().to_string();
             let (_, time_spent, _) = extract_task_meta(node);
 
-            let bucket_idx = category_order
-                .iter()
-                .position(|c| c == &cat)
-                .unwrap_or(5);
+            let bucket_idx = category_order.iter().position(|c| c == &cat).unwrap_or(5);
             buckets[bucket_idx].push(ReviewEntry::ReviewItem {
                 text,
                 file_name,

--- a/src/bin/patto-preview-tui/tasks.rs
+++ b/src/bin/patto-preview-tui/tasks.rs
@@ -16,7 +16,24 @@ pub(crate) fn task_status_icon(status: &TaskStatus) -> &'static str {
     }
 }
 
-/// Extract task metadata (status, time_spent string, started_at string) from an `AstNode`.
+/// Format a total number of minutes as a human-readable string.
+fn fmt_minutes(total: u32) -> String {
+    let h = total / 60;
+    let m = total % 60;
+    if h > 0 && m > 0 {
+        format!("{}h{}m", h, m)
+    } else if h > 0 {
+        format!("{}h", h)
+    } else {
+        format!("{}m", m)
+    }
+}
+
+/// Extract task metadata (status, total_time_spent string, started_at string) from an `AstNode`.
+///
+/// For Doing tasks with a `started_at` datetime, `time_spent` is the **total**
+/// elapsed time: accumulated `time_spent` + live elapsed since `started_at`,
+/// matching the behaviour of PR #103 in the Lua trouble/fidget sources.
 fn extract_task_meta(
     node: &patto::parser::AstNode,
 ) -> (TaskStatus, Option<String>, Option<String>) {
@@ -29,19 +46,37 @@ fn extract_task_meta(
                 ..
             } = prop
             {
-                let ts_str = time_spent.as_ref().map(|d| {
-                    if d.hours > 0 && d.minutes > 0 {
-                        format!("{}h{}m", d.hours, d.minutes)
-                    } else if d.hours > 0 {
-                        format!("{}h", d.hours)
+                // Base accumulated minutes from stored time_spent field.
+                let base_minutes: u32 = time_spent
+                    .as_ref()
+                    .map(|d| d.hours * 60 + d.minutes)
+                    .unwrap_or(0);
+
+                // Live session minutes: only added for Doing tasks that have a started_at datetime.
+                let live_minutes: u32 = if matches!(status, TaskStatus::Doing) {
+                    if let Some(Deadline::DateTime(dt)) = started_at {
+                        let now = Local::now().naive_local();
+                        let elapsed = now.signed_duration_since(*dt);
+                        elapsed.num_minutes().max(0) as u32
                     } else {
-                        format!("{}m", d.minutes)
+                        0
                     }
-                });
+                } else {
+                    0
+                };
+
+                let total_minutes = base_minutes + live_minutes;
+                let ts_str = if total_minutes > 0 {
+                    Some(fmt_minutes(total_minutes))
+                } else {
+                    None
+                };
+
                 let sa_str = started_at.as_ref().and_then(|dl| match dl {
                     Deadline::DateTime(dt) => Some(format!("{:02}:{:02}", dt.hour(), dt.minute())),
                     _ => None,
                 });
+
                 return (status.clone(), ts_str, sa_str);
             }
         }

--- a/src/bin/patto-preview-tui/tasks.rs
+++ b/src/bin/patto-preview-tui/tasks.rs
@@ -123,7 +123,110 @@ pub(crate) fn deadline_category(due: &Deadline) -> DeadlineCategory {
     }
 }
 
-/// A single display entry in the flat tasks list.
+/// Which view is currently shown in the tasks panel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TasksView {
+    /// Upcoming / active tasks, grouped by deadline.
+    Upcoming,
+    /// Recently completed tasks, grouped by recency.
+    Review,
+}
+
+/// Recency grouping for completed tasks — mirrors the Lua `patto_tasks_review` source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CompletedCategory {
+    Today,
+    Yesterday,
+    ThisWeek,
+    LastWeek,
+    ThisMonth,
+    Older,
+}
+
+impl CompletedCategory {
+    pub(crate) fn label(&self) -> &'static str {
+        match self {
+            CompletedCategory::Today => "✓ Today",
+            CompletedCategory::Yesterday => "✓ Yesterday",
+            CompletedCategory::ThisWeek => "✓ This Week",
+            CompletedCategory::LastWeek => "✓ Last Week",
+            CompletedCategory::ThisMonth => "✓ This Month",
+            CompletedCategory::Older => "✓ Older",
+        }
+    }
+
+    /// Ordering index (smaller = more recent).
+    pub(crate) fn order(&self) -> usize {
+        match self {
+            CompletedCategory::Today => 0,
+            CompletedCategory::Yesterday => 1,
+            CompletedCategory::ThisWeek => 2,
+            CompletedCategory::LastWeek => 3,
+            CompletedCategory::ThisMonth => 4,
+            CompletedCategory::Older => 5,
+        }
+    }
+}
+
+/// Classify a completed task's `completed_at` date into a recency bucket.
+pub(crate) fn completed_category(date: chrono::NaiveDate) -> CompletedCategory {
+    use chrono::Datelike;
+    let today = Local::now().date_naive();
+    let diff = (today - date).num_days();
+    if diff == 0 {
+        CompletedCategory::Today
+    } else if diff == 1 {
+        CompletedCategory::Yesterday
+    } else {
+        // Day of week: Monday=0 … Sunday=6
+        let dow = today.weekday().num_days_from_monday() as i64;
+        // Start of this week (Monday)
+        let this_week_start = today - chrono::Duration::days(dow);
+        // Start of last week
+        let last_week_start = this_week_start - chrono::Duration::days(7);
+        // Start of this month
+        let this_month_start =
+            chrono::NaiveDate::from_ymd_opt(today.year(), today.month(), 1).unwrap_or(today);
+
+        if date >= this_week_start {
+            CompletedCategory::ThisWeek
+        } else if date >= last_week_start {
+            CompletedCategory::LastWeek
+        } else if date >= this_month_start {
+            CompletedCategory::ThisMonth
+        } else {
+            CompletedCategory::Older
+        }
+    }
+}
+
+/// A single display entry in the flat review (completed-tasks) list.
+#[derive(Clone)]
+pub(crate) enum ReviewEntry {
+    /// Recency group section header.
+    SectionHeader(String),
+    /// A single completed task item.
+    ReviewItem {
+        text: String,
+        file_name: String,
+        uri: Url,
+        /// 0-based line number within the file.
+        line: usize,
+        /// Formatted `completed_at` date string `YYYY-MM-DD`.
+        completed_at: String,
+        /// Formatted time-spent string, e.g. `"1h30m"`.
+        time_spent: Option<String>,
+        category: CompletedCategory,
+    },
+    /// Placeholder text when list is empty.
+    Placeholder(String),
+}
+
+impl ReviewEntry {
+    pub(crate) fn is_selectable(&self) -> bool {
+        matches!(self, ReviewEntry::ReviewItem { .. })
+    }
+}
 #[derive(Clone)]
 pub(crate) enum TaskEntry {
     /// Deadline group section header.
@@ -157,16 +260,25 @@ impl TaskEntry {
 /// Self-contained tasks panel state.
 pub(crate) struct TasksPanel {
     pub(crate) visible: bool,
+    /// Which view is currently showing.
+    pub(crate) view: TasksView,
+    /// Upcoming/active task entries.
     pub(crate) entries: Vec<TaskEntry>,
     pub(crate) list_state: ListState,
+    /// Completed-task review entries.
+    pub(crate) review_entries: Vec<ReviewEntry>,
+    pub(crate) review_list_state: ListState,
 }
 
 impl TasksPanel {
     pub(crate) fn new() -> Self {
         Self {
             visible: false,
+            view: TasksView::Upcoming,
             entries: Vec::new(),
             list_state: ListState::default(),
+            review_entries: Vec::new(),
+            review_list_state: ListState::default(),
         }
     }
 
@@ -180,7 +292,17 @@ impl TasksPanel {
 
     pub(crate) fn close(&mut self) {
         self.visible = false;
+        self.view = TasksView::Upcoming;
         self.list_state = ListState::default();
+        self.review_list_state = ListState::default();
+    }
+
+    /// Toggle between Upcoming and Review views.
+    pub(crate) fn toggle_view(&mut self) {
+        self.view = match self.view {
+            TasksView::Upcoming => TasksView::Review,
+            TasksView::Review => TasksView::Upcoming,
+        };
     }
 
     /// Re-fetch tasks from the repository and rebuild the flat entry list.
@@ -195,6 +317,30 @@ impl TasksPanel {
         {
             self.list_state = ListState::default();
             self.select_first_item();
+        }
+    }
+
+    /// Re-fetch completed tasks and rebuild the review entry list.
+    pub(crate) fn refresh_review(&mut self, repository: &Repository) {
+        use chrono::Datelike;
+        let today = Local::now().date_naive();
+        // Date range: from start-of-last-week or start-of-this-month (whichever is earlier)
+        let dow = today.weekday().num_days_from_monday() as i64;
+        let this_week_start = today - chrono::Duration::days(dow);
+        let last_week_start = this_week_start - chrono::Duration::days(7);
+        let this_month_start =
+            chrono::NaiveDate::from_ymd_opt(today.year(), today.month(), 1).unwrap_or(today);
+        let from = last_week_start.min(this_month_start);
+
+        let completed = repository.aggregate_completed_tasks(Some(from), Some(today));
+        self.rebuild_review_entries(completed);
+        if self
+            .review_list_state
+            .selected
+            .map_or(true, |i| i >= self.review_entries.len())
+        {
+            self.review_list_state = ListState::default();
+            self.select_first_review_item();
         }
     }
 
@@ -262,6 +408,71 @@ impl TasksPanel {
         self.entries = entries;
     }
 
+    /// Rebuild the review entry list from completed task data, grouped by recency.
+    fn rebuild_review_entries(
+        &mut self,
+        completed: Vec<(Url, patto::parser::AstNode, chrono::NaiveDate)>,
+    ) {
+        let category_order = [
+            CompletedCategory::Today,
+            CompletedCategory::Yesterday,
+            CompletedCategory::ThisWeek,
+            CompletedCategory::LastWeek,
+            CompletedCategory::ThisMonth,
+            CompletedCategory::Older,
+        ];
+
+        let mut buckets: Vec<Vec<ReviewEntry>> = vec![Vec::new(); category_order.len()];
+
+        for (uri, node, date) in &completed {
+            let cat = completed_category(*date);
+            let completed_at = date.format("%Y-%m-%d").to_string();
+            let file_name = uri
+                .to_file_path()
+                .ok()
+                .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+                .unwrap_or_else(|| uri.to_string());
+            let line = node.location().row;
+            let text = node.extract_str().trim_start().to_string();
+            let (_, time_spent, _) = extract_task_meta(node);
+
+            let bucket_idx = category_order
+                .iter()
+                .position(|c| c == &cat)
+                .unwrap_or(5);
+            buckets[bucket_idx].push(ReviewEntry::ReviewItem {
+                text,
+                file_name,
+                uri: uri.clone(),
+                line,
+                completed_at,
+                time_spent,
+                category: cat,
+            });
+        }
+
+        // Reverse each bucket so most-recently-completed appears first.
+        for bucket in &mut buckets {
+            bucket.reverse();
+        }
+
+        let mut entries: Vec<ReviewEntry> = Vec::new();
+        for (cat, bucket) in category_order.iter().zip(buckets.iter()) {
+            if !bucket.is_empty() {
+                entries.push(ReviewEntry::SectionHeader(cat.label().to_string()));
+                entries.extend_from_slice(bucket);
+            }
+        }
+
+        if entries.is_empty() {
+            entries.push(ReviewEntry::Placeholder(
+                "  (no completed tasks in range)".to_string(),
+            ));
+        }
+
+        self.review_entries = entries;
+    }
+
     /// Select the first selectable entry.
     fn select_first_item(&mut self) {
         for (i, entry) in self.entries.iter().enumerate() {
@@ -272,7 +483,24 @@ impl TasksPanel {
         }
     }
 
+    /// Select the first selectable review entry.
+    fn select_first_review_item(&mut self) {
+        for (i, entry) in self.review_entries.iter().enumerate() {
+            if entry.is_selectable() {
+                self.review_list_state.select(Some(i));
+                return;
+            }
+        }
+    }
+
     pub(crate) fn navigate_down(&mut self) {
+        match self.view {
+            TasksView::Upcoming => self.navigate_down_upcoming(),
+            TasksView::Review => self.navigate_down_review(),
+        }
+    }
+
+    fn navigate_down_upcoming(&mut self) {
         let len = self.entries.len();
         if len == 0 {
             return;
@@ -290,7 +518,32 @@ impl TasksPanel {
         }
     }
 
+    fn navigate_down_review(&mut self) {
+        let len = self.review_entries.len();
+        if len == 0 {
+            return;
+        }
+        let start = self.review_list_state.selected.unwrap_or(0);
+        let mut next = (start + 1) % len;
+        for _ in 0..len {
+            if self.review_entries[next].is_selectable() {
+                break;
+            }
+            next = (next + 1) % len;
+        }
+        if self.review_entries[next].is_selectable() {
+            self.review_list_state.select(Some(next));
+        }
+    }
+
     pub(crate) fn navigate_up(&mut self) {
+        match self.view {
+            TasksView::Upcoming => self.navigate_up_upcoming(),
+            TasksView::Review => self.navigate_up_review(),
+        }
+    }
+
+    fn navigate_up_upcoming(&mut self) {
         let len = self.entries.len();
         if len == 0 {
             return;
@@ -308,16 +561,46 @@ impl TasksPanel {
         }
     }
 
-    /// Resolve the current selection to a navigation target: `(uri, line)`.
-    pub(crate) fn resolve_cursor(&self) -> Option<(Url, usize)> {
-        let idx = self.list_state.selected?;
-        match self.entries.get(idx)? {
-            TaskEntry::TaskItem { uri, line, .. } => Some((uri.clone(), *line)),
-            _ => None,
+    fn navigate_up_review(&mut self) {
+        let len = self.review_entries.len();
+        if len == 0 {
+            return;
+        }
+        let start = self.review_list_state.selected.unwrap_or(0);
+        let mut prev = if start == 0 { len - 1 } else { start - 1 };
+        for _ in 0..len {
+            if self.review_entries[prev].is_selectable() {
+                break;
+            }
+            prev = if prev == 0 { len - 1 } else { prev - 1 };
+        }
+        if self.review_entries[prev].is_selectable() {
+            self.review_list_state.select(Some(prev));
         }
     }
 
-    /// Return a list of (status_icon, text) for all active (Doing/Paused) tasks.
+    /// Resolve the current selection to a navigation target: `(uri, line)`.
+    /// Dispatches to the current view.
+    pub(crate) fn resolve_cursor(&self) -> Option<(Url, usize)> {
+        match self.view {
+            TasksView::Upcoming => {
+                let idx = self.list_state.selected?;
+                match self.entries.get(idx)? {
+                    TaskEntry::TaskItem { uri, line, .. } => Some((uri.clone(), *line)),
+                    _ => None,
+                }
+            }
+            TasksView::Review => {
+                let idx = self.review_list_state.selected?;
+                match self.review_entries.get(idx)? {
+                    ReviewEntry::ReviewItem { uri, line, .. } => Some((uri.clone(), *line)),
+                    _ => None,
+                }
+            }
+        }
+    }
+
+    /// Return a list of (status, text) for all active (Doing/Paused) tasks.
     /// Used by the fidget-style overlay.
     pub(crate) fn active_tasks(&self) -> Vec<(TaskStatus, String)> {
         self.entries

--- a/src/bin/patto-preview-tui/tasks.rs
+++ b/src/bin/patto-preview-tui/tasks.rs
@@ -1,7 +1,55 @@
-use chrono::Local;
-use patto::{parser::Deadline, repository::Repository};
+use chrono::{Local, Timelike};
+use patto::{
+    parser::{AstNodeKind, Deadline, Property, TaskStatus},
+    repository::Repository,
+};
 use tower_lsp::lsp_types::Url;
 use tui_widget_list::ListState;
+
+/// Return the status-icon character for a `TaskStatus`.
+pub(crate) fn task_status_icon(status: &TaskStatus) -> &'static str {
+    match status {
+        TaskStatus::Todo => "○",
+        TaskStatus::Doing => "◑",
+        TaskStatus::Paused => "⏸",
+        TaskStatus::Done => "✓",
+    }
+}
+
+/// Extract task metadata (status, time_spent string, started_at string) from an `AstNode`.
+fn extract_task_meta(
+    node: &patto::parser::AstNode,
+) -> (TaskStatus, Option<String>, Option<String>) {
+    if let AstNodeKind::Line { ref properties } = node.kind() {
+        for prop in properties {
+            if let Property::Task {
+                status,
+                time_spent,
+                started_at,
+                ..
+            } = prop
+            {
+                let ts_str = time_spent.as_ref().map(|d| {
+                    if d.hours > 0 && d.minutes > 0 {
+                        format!("{}h{}m", d.hours, d.minutes)
+                    } else if d.hours > 0 {
+                        format!("{}h", d.hours)
+                    } else {
+                        format!("{}m", d.minutes)
+                    }
+                });
+                let sa_str = started_at.as_ref().and_then(|dl| match dl {
+                    Deadline::DateTime(dt) => {
+                        Some(format!("{:02}:{:02}", dt.hour(), dt.minute()))
+                    }
+                    _ => None,
+                });
+                return (status.clone(), ts_str, sa_str);
+            }
+        }
+    }
+    (TaskStatus::Todo, None, None)
+}
 
 /// Deadline grouping categories, matching the Lua trouble.nvim source behaviour.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -80,7 +128,7 @@ pub(crate) fn deadline_category(due: &Deadline) -> DeadlineCategory {
 pub(crate) enum TaskEntry {
     /// Deadline group section header.
     SectionHeader(String),
-    /// A single task item.
+    /// A single task item (upcoming / active).
     TaskItem {
         text: String,
         file_name: String,
@@ -89,6 +137,12 @@ pub(crate) enum TaskEntry {
         line: usize,
         due_str: String,
         category: DeadlineCategory,
+        /// Task status (○ todo / ◑ doing / ⏸ paused).
+        status: TaskStatus,
+        /// Formatted time-spent string, e.g. `"1h30m"`. Present for doing/paused tasks.
+        time_spent: Option<String>,
+        /// Formatted started-at string (HH:MM). Present for doing/paused tasks.
+        started_at: Option<String>,
     },
     /// Placeholder "(none)" when a section is empty.
     Placeholder(String),
@@ -177,6 +231,7 @@ impl TasksPanel {
                 .unwrap_or_else(|| uri.to_string());
             let line = node.location().row;
             let text = node.extract_str().trim_start().to_string();
+            let (status, time_spent, started_at) = extract_task_meta(node);
 
             let bucket_idx = category_order.iter().position(|c| *c == cat).unwrap_or(5);
             buckets[bucket_idx].push(TaskEntry::TaskItem {
@@ -186,6 +241,9 @@ impl TasksPanel {
                 line,
                 due_str,
                 category: cat,
+                status,
+                time_spent,
+                started_at,
             });
         }
 
@@ -257,5 +315,21 @@ impl TasksPanel {
             TaskEntry::TaskItem { uri, line, .. } => Some((uri.clone(), *line)),
             _ => None,
         }
+    }
+
+    /// Return a list of (status_icon, text) for all active (Doing/Paused) tasks.
+    /// Used by the fidget-style overlay.
+    pub(crate) fn active_tasks(&self) -> Vec<(TaskStatus, String)> {
+        self.entries
+            .iter()
+            .filter_map(|e| {
+                if let TaskEntry::TaskItem { status, text, .. } = e {
+                    if matches!(status, TaskStatus::Doing | TaskStatus::Paused) {
+                        return Some((status.clone(), text.clone()));
+                    }
+                }
+                None
+            })
+            .collect()
     }
 }

--- a/src/bin/patto-preview-tui/tasks.rs
+++ b/src/bin/patto-preview-tui/tasks.rs
@@ -1,4 +1,4 @@
-use chrono::{Local, Timelike};
+use chrono::{Local, NaiveDateTime, TimeDelta};
 use patto::{
     parser::{AstNodeKind, Deadline, Property, TaskStatus},
     repository::Repository,
@@ -16,27 +16,56 @@ pub(crate) fn task_status_icon(status: &TaskStatus) -> &'static str {
     }
 }
 
-/// Format a total number of minutes as a human-readable string.
-fn fmt_minutes(total: u32) -> String {
-    let h = total / 60;
-    let m = total % 60;
-    if h > 0 && m > 0 {
+/// Format a `TimeDelta` as a human-readable `"1h30m"` / `"45m"` / `"2h"` string.
+/// Returns `None` when the duration is zero or negative.
+pub(crate) fn fmt_timedelta(td: TimeDelta) -> Option<String> {
+    let total_mins = td.num_minutes();
+    if total_mins <= 0 {
+        return None;
+    }
+    let h = (total_mins / 60) as u32;
+    let m = (total_mins % 60) as u32;
+    let s = if h > 0 && m > 0 {
         format!("{}h{}m", h, m)
     } else if h > 0 {
         format!("{}h", h)
     } else {
         format!("{}m", m)
-    }
+    };
+    Some(s)
 }
 
-/// Extract task metadata (status, total_time_spent string, started_at string) from an `AstNode`.
+/// Compute total elapsed time for a task **at the current moment**.
 ///
-/// For Doing tasks with a `started_at` datetime, `time_spent` is the **total**
-/// elapsed time: accumulated `time_spent` + live elapsed since `started_at`,
-/// matching the behaviour of PR #103 in the Lua trouble/fidget sources.
+/// For `Doing` tasks with a `started_at_dt`, the live session duration
+/// (`now − started_at_dt`) is added to `base`.  For all other statuses the
+/// raw `base` is returned unchanged.
+///
+/// Must be called at **render time** (not at data-load time) so the counter
+/// stays live without requiring a repository re-scan.
+pub(crate) fn total_elapsed(
+    status: &TaskStatus,
+    base: TimeDelta,
+    started_at_dt: Option<NaiveDateTime>,
+) -> TimeDelta {
+    if matches!(status, TaskStatus::Doing) {
+        if let Some(dt) = started_at_dt {
+            let live = Local::now().naive_local() - dt;
+            if live > TimeDelta::zero() {
+                return base + live;
+            }
+        }
+    }
+    base
+}
+
+/// Extract raw task metadata from an `AstNode`.
+///
+/// Returns `(status, base_time_spent: TimeDelta, started_at_dt)`.
+/// Callers compute the live-elapsed total at render time via [`total_elapsed`].
 fn extract_task_meta(
     node: &patto::parser::AstNode,
-) -> (TaskStatus, Option<String>, Option<String>) {
+) -> (TaskStatus, TimeDelta, Option<NaiveDateTime>) {
     if let AstNodeKind::Line { ref properties } = node.kind() {
         for prop in properties {
             if let Property::Task {
@@ -46,42 +75,70 @@ fn extract_task_meta(
                 ..
             } = prop
             {
-                // Base accumulated minutes from stored time_spent field.
-                let base_minutes: u32 = time_spent
+                let base = time_spent
                     .as_ref()
-                    .map(|d| d.hours * 60 + d.minutes)
-                    .unwrap_or(0);
+                    .map(|d| TimeDelta::minutes((d.hours * 60 + d.minutes) as i64))
+                    .unwrap_or(TimeDelta::zero());
 
-                // Live session minutes: only added for Doing tasks that have a started_at datetime.
-                let live_minutes: u32 = if matches!(status, TaskStatus::Doing) {
-                    if let Some(Deadline::DateTime(dt)) = started_at {
-                        let now = Local::now().naive_local();
-                        let elapsed = now.signed_duration_since(*dt);
-                        elapsed.num_minutes().max(0) as u32
-                    } else {
-                        0
-                    }
-                } else {
-                    0
-                };
-
-                let total_minutes = base_minutes + live_minutes;
-                let ts_str = if total_minutes > 0 {
-                    Some(fmt_minutes(total_minutes))
-                } else {
-                    None
-                };
-
-                let sa_str = started_at.as_ref().and_then(|dl| match dl {
-                    Deadline::DateTime(dt) => Some(format!("{:02}:{:02}", dt.hour(), dt.minute())),
+                let started_at_dt = started_at.as_ref().and_then(|dl| match dl {
+                    Deadline::DateTime(dt) => Some(*dt),
                     _ => None,
                 });
 
-                return (status.clone(), ts_str, sa_str);
+                return (status.clone(), base, started_at_dt);
             }
         }
     }
-    (TaskStatus::Todo, None, None)
+    (TaskStatus::Todo, TimeDelta::zero(), None)
+}
+
+/// Return the human-readable text of a node with all `{@task …}` property
+/// annotations removed.
+///
+/// `Property::Task` carries a `location: Location` whose `span` is the
+/// byte-range of the annotation within the raw source line.  We collect all
+/// such spans, sort them, then reassemble the non-annotated fragments and
+/// collapse runs of whitespace left behind.
+fn node_display_text(node: &patto::parser::AstNode) -> String {
+    use patto::parser::Property;
+
+    let raw = node.extract_str();
+
+    let mut spans_to_remove: Vec<(usize, usize)> = Vec::new();
+    if let AstNodeKind::Line { ref properties } = node.kind() {
+        for prop in properties {
+            if let Property::Task { location, .. } = prop {
+                let s = location.span.0;
+                let e = location.span.1;
+                if e > s && e <= raw.len() {
+                    spans_to_remove.push((s, e));
+                }
+            }
+        }
+    }
+
+    if spans_to_remove.is_empty() {
+        return raw.trim().to_string();
+    }
+
+    spans_to_remove.sort_unstable();
+
+    // Build output from the non-removed byte slices.
+    let mut out = String::with_capacity(raw.len());
+    let mut cursor = 0usize;
+    for (s, e) in spans_to_remove {
+        if s > cursor {
+            out.push_str(&raw[cursor..s]);
+        }
+        cursor = e;
+    }
+    if cursor < raw.len() {
+        out.push_str(&raw[cursor..]);
+    }
+
+    // Collapse consecutive whitespace and trim.
+    let collapsed: String = out.split_whitespace().collect::<Vec<_>>().join(" ");
+    collapsed
 }
 
 /// Deadline grouping categories, matching the Lua trouble.nvim source behaviour.
@@ -247,8 +304,8 @@ pub(crate) enum ReviewEntry {
         line: usize,
         /// Formatted `completed_at` date string `YYYY-MM-DD`.
         completed_at: String,
-        /// Formatted time-spent string, e.g. `"1h30m"`.
-        time_spent: Option<String>,
+        /// Total time spent (accumulated; no live session for completed tasks).
+        time_spent: TimeDelta,
         category: CompletedCategory,
     },
     /// Placeholder text when list is empty.
@@ -275,10 +332,10 @@ pub(crate) enum TaskEntry {
         category: DeadlineCategory,
         /// Task status (○ todo / ◑ doing / ⏸ paused).
         status: TaskStatus,
-        /// Formatted time-spent string, e.g. `"1h30m"`. Present for doing/paused tasks.
-        time_spent: Option<String>,
-        /// Formatted started-at string (HH:MM). Present for doing/paused tasks.
-        started_at: Option<String>,
+        /// Accumulated (stored) time-spent. Add live elapsed at render time via [`total_elapsed`].
+        base_time_spent: TimeDelta,
+        /// Raw started_at datetime for computing live elapsed at render time.
+        started_at_dt: Option<NaiveDateTime>,
     },
     /// Placeholder "(none)" when a section is empty.
     Placeholder(String),
@@ -409,8 +466,8 @@ impl TasksPanel {
                 .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
                 .unwrap_or_else(|| uri.to_string());
             let line = node.location().row;
-            let text = node.extract_str().trim_start().to_string();
-            let (status, time_spent, started_at) = extract_task_meta(node);
+            let text = node_display_text(node);
+            let (status, base_time_spent, started_at_dt) = extract_task_meta(node);
 
             let bucket_idx = category_order.iter().position(|c| *c == cat).unwrap_or(5);
             buckets[bucket_idx].push(TaskEntry::TaskItem {
@@ -421,8 +478,8 @@ impl TasksPanel {
                 due_str,
                 category: cat,
                 status,
-                time_spent,
-                started_at,
+                base_time_spent,
+                started_at_dt,
             });
         }
 
@@ -466,7 +523,7 @@ impl TasksPanel {
                 .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
                 .unwrap_or_else(|| uri.to_string());
             let line = node.location().row;
-            let text = node.extract_str().trim_start().to_string();
+            let text = node_display_text(node);
             let (_, time_spent, _) = extract_task_meta(node);
 
             let bucket_idx = category_order.iter().position(|c| c == &cat).unwrap_or(5);
@@ -630,15 +687,29 @@ impl TasksPanel {
         }
     }
 
-    /// Return a list of (status, text) for all active (Doing/Paused) tasks.
-    /// Used by the fidget-style overlay.
-    pub(crate) fn active_tasks(&self) -> Vec<(TaskStatus, String)> {
+    /// Return raw data for all active (Doing/Paused) tasks.
+    /// The overlay computes live elapsed at render time via [`total_elapsed`].
+    pub(crate) fn active_tasks(
+        &self,
+    ) -> Vec<(TaskStatus, String, TimeDelta, Option<NaiveDateTime>)> {
         self.entries
             .iter()
             .filter_map(|e| {
-                if let TaskEntry::TaskItem { status, text, .. } = e {
+                if let TaskEntry::TaskItem {
+                    status,
+                    text,
+                    base_time_spent,
+                    started_at_dt,
+                    ..
+                } = e
+                {
                     if matches!(status, TaskStatus::Doing | TaskStatus::Paused) {
-                        return Some((status.clone(), text.clone()));
+                        return Some((
+                            status.clone(),
+                            text.clone(),
+                            *base_time_spent,
+                            *started_at_dt,
+                        ));
                     }
                 }
                 None

--- a/src/bin/patto-preview-tui/ui.rs
+++ b/src/bin/patto-preview-tui/ui.rs
@@ -1224,29 +1224,52 @@ fn draw_tasks_upcoming_content(
             } => {
                 use crate::tasks::{task_status_icon, DeadlineCategory};
                 use patto::parser::TaskStatus;
-                let base_style = match category {
-                    DeadlineCategory::Overdue => Style::default().fg(Color::Red),
-                    DeadlineCategory::Today => Style::default().fg(Color::Yellow),
-                    _ => Style::default().fg(Color::White),
+
+                // Base text / selection style
+                let text_fg = match category {
+                    DeadlineCategory::Overdue => Color::Red,
+                    DeadlineCategory::Today => Color::Yellow,
+                    _ => Color::White,
                 };
-                let row_style = if is_sel {
-                    base_style.add_modifier(Modifier::REVERSED)
+                let (text_style, prefix_str) = if is_sel {
+                    (
+                        Style::default()
+                            .fg(Color::Black)
+                            .bg(text_fg)
+                            .add_modifier(Modifier::BOLD),
+                        format!(">{} ", task_status_icon(status)),
+                    )
                 } else {
-                    base_style
+                    (
+                        Style::default().fg(text_fg),
+                        format!(" {} ", task_status_icon(status)),
+                    )
                 };
 
-                // Build rich row: "{icon} {text}  [{due}] [⏱ ts] [▶ sa]  {file}"
-                let icon = task_status_icon(status);
-                let prefix = if is_sel {
-                    format!(">{} ", icon)
+                // Due date chip style: colored bg badge
+                let chip_style = if is_sel {
+                    // When selected, chip also inverts
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(text_fg)
+                        .add_modifier(Modifier::BOLD)
                 } else {
-                    format!(" {} ", icon)
+                    match category {
+                        DeadlineCategory::Overdue => Style::default()
+                            .fg(Color::Black)
+                            .bg(Color::Red)
+                            .add_modifier(Modifier::BOLD),
+                        DeadlineCategory::Today => Style::default()
+                            .fg(Color::Black)
+                            .bg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD),
+                        DeadlineCategory::Tomorrow => Style::default()
+                            .fg(Color::Black)
+                            .bg(Color::Cyan),
+                        _ => Style::default().fg(Color::DarkGray).bg(Color::Black),
+                    }
                 };
-                let date_part = if due_str.is_empty() {
-                    String::new()
-                } else {
-                    format!("[{}] ", due_str)
-                };
+
                 // Time-tracking chips (only for doing/paused)
                 let tracking = match status {
                     TaskStatus::Doing | TaskStatus::Paused => {
@@ -1261,12 +1284,18 @@ fn draw_tasks_upcoming_content(
                     }
                     _ => String::new(),
                 };
-                let suffix = format!("  {}", file_name);
-                // Available space for task text
-                let fixed_len = prefix.chars().count()
-                    + date_part.chars().count()
+
+                // Compute how much space is left for the task text
+                let chip_str = if due_str.is_empty() {
+                    String::new()
+                } else {
+                    format!(" {} ", due_str)
+                };
+                let suffix_str = format!("  {}", file_name);
+                let fixed_len = prefix_str.chars().count()
+                    + chip_str.chars().count()
                     + tracking.chars().count()
-                    + suffix.chars().count();
+                    + suffix_str.chars().count();
                 let text_max = inner_width.saturating_sub(fixed_len);
                 let truncated_text = if text.chars().count() > text_max {
                     let s: String = text.chars().take(text_max.saturating_sub(1)).collect();
@@ -1274,9 +1303,24 @@ fn draw_tasks_upcoming_content(
                 } else {
                     text.clone()
                 };
-                let row_text =
-                    format!("{}{}{}{}{}", prefix, date_part, truncated_text, tracking, suffix);
-                lines.push(Line::from(Span::styled(row_text, row_style)));
+
+                // Build multi-span line
+                let mut spans = vec![Span::styled(prefix_str, text_style)];
+                if !chip_str.is_empty() {
+                    spans.push(Span::styled(chip_str, chip_style));
+                    spans.push(Span::raw(" "));
+                }
+                spans.push(Span::styled(truncated_text, text_style));
+                if !tracking.is_empty() {
+                    let tracking_style = if is_sel {
+                        text_style
+                    } else {
+                        Style::default().fg(Color::DarkGray)
+                    };
+                    spans.push(Span::styled(tracking, tracking_style));
+                }
+                spans.push(Span::styled(suffix_str, Style::default().fg(Color::DarkGray)));
+                lines.push(Line::from(spans));
             }
         }
     }

--- a/src/bin/patto-preview-tui/ui.rs
+++ b/src/bin/patto-preview-tui/ui.rs
@@ -1012,9 +1012,7 @@ fn draw_fullscreen_image(frame: &mut Frame, app: &mut App, root_dir: &Path, src:
 /// Fidget-style overlay showing active (Doing/Paused) tasks in the bottom-right corner
 /// of the content area. Only drawn when the tasks panel is closed.
 fn draw_active_task_overlay(frame: &mut Frame, content_area: Rect, app: &App) {
-    use crate::tasks::task_status_icon;
     use patto::parser::TaskStatus;
-
     let active = app.tasks.active_tasks();
     if active.is_empty() {
         return;
@@ -1025,34 +1023,15 @@ fn draw_active_task_overlay(frame: &mut Frame, content_area: Rect, app: &App) {
     let tasks_to_show: Vec<_> = active.iter().take(max_rows).collect();
     let num_rows = tasks_to_show.len() as u16;
 
-    // Width: up to 40% of content width, min 20 cols.
-    let max_w = (content_area.width * 40 / 100)
+    // Max width cap: 60% of content width, min 20 cols.
+    let max_w = (content_area.width * 60 / 100)
         .max(20)
-        .min(content_area.width);
+        .min(content_area.width) as usize;
 
-    // Position: bottom-right of content area, 1 row above the bottom edge.
-    let x = content_area.x + content_area.width.saturating_sub(max_w);
-    let y = content_area
-        .y
-        .saturating_add(content_area.height)
-        .saturating_sub(num_rows + 1);
-
-    // Clamp to content area
-    if y < content_area.y || content_area.height < num_rows + 1 {
-        return;
-    }
-
-    let overlay_area = Rect {
-        x,
-        y,
-        width: max_w,
-        height: num_rows,
-    };
-
-    let inner_w = max_w as usize;
-
+    // Build lines first so we can measure actual rendered width.
     let mut lines: Vec<Line> = Vec::new();
-    for (status, text) in &tasks_to_show {
+    for (status, text, base_time_spent, started_at_dt) in &tasks_to_show {
+        use crate::tasks::{fmt_timedelta, total_elapsed};
         let (annotation, ann_style, text_style) = match status {
             TaskStatus::Doing => (
                 "◑ doing",
@@ -1073,9 +1052,14 @@ fn draw_active_task_overlay(frame: &mut Frame, content_area: Rect, app: &App) {
             _ => continue,
         };
 
-        let ann_len = annotation.chars().count();
-        let space = 1usize; // gap between annotation and text
-        let text_max = inner_w.saturating_sub(ann_len + space + 1);
+        let elapsed = total_elapsed(status, *base_time_spent, *started_at_dt);
+        let time_chip = fmt_timedelta(elapsed)
+            .map(|s| format!(" ⏱ {}", s))
+            .unwrap_or_default();
+
+        // " {annotation} " prefix + " " gap
+        let prefix_len = 1 + annotation.chars().count() + 2;
+        let text_max = max_w.saturating_sub(prefix_len + time_chip.chars().count());
         let truncated = if text.chars().count() > text_max {
             let s: String = text.chars().take(text_max.saturating_sub(1)).collect();
             format!("{}…", s)
@@ -1083,11 +1067,55 @@ fn draw_active_task_overlay(frame: &mut Frame, content_area: Rect, app: &App) {
             text.clone()
         };
 
-        lines.push(Line::from(vec![
+        let mut spans = vec![
             Span::styled(format!(" {} ", annotation), ann_style),
             Span::styled(format!(" {}", truncated), text_style),
-        ]));
+        ];
+        if !time_chip.is_empty() {
+            spans.push(Span::styled(
+                time_chip,
+                Style::default().fg(Color::DarkGray).bg(Color::Black),
+            ));
+        }
+        lines.push(Line::from(spans));
     }
+
+    if lines.is_empty() {
+        return;
+    }
+
+    // Measure actual width needed (sum of span char widths per line).
+    let actual_w = lines
+        .iter()
+        .map(|l| {
+            l.spans
+                .iter()
+                .map(|s| s.content.chars().count())
+                .sum::<usize>()
+        })
+        .max()
+        .unwrap_or(0)
+        .min(max_w) as u16;
+
+    let num_rows = lines.len() as u16;
+
+    // Position: bottom-right of content area, 1 row above the bottom edge.
+    let x = content_area.x + content_area.width.saturating_sub(actual_w);
+    let y = content_area
+        .y
+        .saturating_add(content_area.height)
+        .saturating_sub(num_rows + 1);
+
+    if y < content_area.y || content_area.height < num_rows + 1 {
+        return;
+    }
+
+    let overlay_area = Rect {
+        x,
+        y,
+        width: actual_w,
+        height: num_rows,
+    };
 
     frame.render_widget(
         Paragraph::new(lines).style(Style::default().bg(Color::Black)),
@@ -1220,85 +1248,80 @@ fn draw_tasks_upcoming_content(
                 due_str,
                 category,
                 status,
-                time_spent,
-                started_at,
+                base_time_spent,
+                started_at_dt,
                 ..
             } => {
-                use crate::tasks::{task_status_icon, DeadlineCategory};
+                use crate::tasks::{
+                    fmt_timedelta, task_status_icon, total_elapsed, DeadlineCategory,
+                };
                 use patto::parser::TaskStatus;
 
-                // Base text / selection style
+                // ── colours ───────────────────────────────────────────────
                 let text_fg = match category {
                     DeadlineCategory::Overdue => Color::Red,
                     DeadlineCategory::Today => Color::Yellow,
                     _ => Color::White,
                 };
-                let (text_style, prefix_str) = if is_sel {
+                let (text_style, sel_prefix) = if is_sel {
                     (
                         Style::default()
                             .fg(Color::Black)
                             .bg(text_fg)
                             .add_modifier(Modifier::BOLD),
-                        format!(">{} ", task_status_icon(status)),
+                        ">",
                     )
                 } else {
-                    (
-                        Style::default().fg(text_fg),
-                        format!(" {} ", task_status_icon(status)),
-                    )
+                    (Style::default().fg(text_fg), " ")
                 };
 
-                // Due date chip style: colored bg badge
-                let chip_style = if is_sel {
-                    // When selected, chip also inverts
-                    Style::default()
-                        .fg(Color::Black)
-                        .bg(text_fg)
-                        .add_modifier(Modifier::BOLD)
+                // ── due-date chip (plain text, coloured fg, no brackets) ──
+                let due_chip_style = if is_sel {
+                    text_style
                 } else {
                     match category {
-                        DeadlineCategory::Overdue => Style::default()
-                            .fg(Color::Black)
-                            .bg(Color::Red)
-                            .add_modifier(Modifier::BOLD),
-                        DeadlineCategory::Today => Style::default()
-                            .fg(Color::Black)
-                            .bg(Color::Yellow)
-                            .add_modifier(Modifier::BOLD),
-                        DeadlineCategory::Tomorrow => {
-                            Style::default().fg(Color::Black).bg(Color::Cyan)
+                        DeadlineCategory::Overdue => {
+                            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
                         }
-                        _ => Style::default().fg(Color::DarkGray).bg(Color::Black),
+                        DeadlineCategory::Today => Style::default().fg(Color::Yellow),
+                        DeadlineCategory::Tomorrow => Style::default().fg(Color::Cyan),
+                        _ => Style::default().fg(Color::DarkGray),
                     }
                 };
+                let due_chip = if due_str.is_empty() {
+                    String::new()
+                } else {
+                    format!(" {}", due_str)
+                };
 
-                // Time-tracking chips (only for doing/paused)
-                let tracking = match status {
+                // ── time chips (doing/paused only, computed at render time) ──
+                let time_chip = match status {
                     TaskStatus::Doing | TaskStatus::Paused => {
-                        let mut parts = String::new();
-                        if let Some(ts) = time_spent {
-                            parts.push_str(&format!(" ⏱{}", ts));
-                        }
-                        if let Some(sa) = started_at {
-                            parts.push_str(&format!(" ▶{}", sa));
-                        }
-                        parts
+                        let elapsed = total_elapsed(status, *base_time_spent, *started_at_dt);
+                        fmt_timedelta(elapsed)
+                            .map(|s| format!(" ⏱ {}", s))
+                            .unwrap_or_default()
                     }
                     _ => String::new(),
                 };
-
-                // Compute how much space is left for the task text
-                let chip_str = if due_str.is_empty() {
-                    String::new()
+                let started_chip = if matches!(status, TaskStatus::Doing) {
+                    started_at_dt
+                        .map(|dt| format!(" ▶ {}", dt.format("%H:%M")))
+                        .unwrap_or_default()
                 } else {
-                    format!(" {} ", due_str)
+                    String::new()
                 };
+
+                // ── layout: prefix + icon + due + " " + text + chips + file ──
+                let prefix_str = format!("{}{} ", sel_prefix, task_status_icon(status));
                 let suffix_str = format!("  {}", file_name);
-                let fixed_len = prefix_str.chars().count()
-                    + chip_str.chars().count()
-                    + tracking.chars().count()
+                let fixed_chars = prefix_str.chars().count()
+                    + due_chip.chars().count()
+                    + 1 // space between due and text
+                    + time_chip.chars().count()
+                    + started_chip.chars().count()
                     + suffix_str.chars().count();
-                let text_max = inner_width.saturating_sub(fixed_len);
+                let text_max = inner_width.saturating_sub(fixed_chars);
                 let truncated_text = if text.chars().count() > text_max {
                     let s: String = text.chars().take(text_max.saturating_sub(1)).collect();
                     format!("{}…", s)
@@ -1306,20 +1329,27 @@ fn draw_tasks_upcoming_content(
                     text.clone()
                 };
 
-                // Build multi-span line
+                // ── build spans ───────────────────────────────────────────
                 let mut spans = vec![Span::styled(prefix_str, text_style)];
-                if !chip_str.is_empty() {
-                    spans.push(Span::styled(chip_str, chip_style));
-                    spans.push(Span::raw(" "));
+                if !due_chip.is_empty() {
+                    spans.push(Span::styled(due_chip, due_chip_style));
                 }
-                spans.push(Span::styled(truncated_text, text_style));
-                if !tracking.is_empty() {
-                    let tracking_style = if is_sel {
+                spans.push(Span::styled(format!(" {}", truncated_text), text_style));
+                if !time_chip.is_empty() {
+                    let chip_style = if is_sel {
                         text_style
                     } else {
-                        Style::default().fg(Color::DarkGray)
+                        Style::default().fg(Color::Blue)
                     };
-                    spans.push(Span::styled(tracking, tracking_style));
+                    spans.push(Span::styled(time_chip, chip_style));
+                }
+                if !started_chip.is_empty() {
+                    let chip_style = if is_sel {
+                        text_style
+                    } else {
+                        Style::default().fg(Color::Yellow)
+                    };
+                    spans.push(Span::styled(started_chip, chip_style));
                 }
                 spans.push(Span::styled(
                     suffix_str,
@@ -1403,10 +1433,11 @@ fn draw_tasks_review_content(
                 // Build row: "{>|space} ✓ {completed_at} {text} [⏱ ts]  {file}"
                 let prefix = if is_sel { "> " } else { "  " };
                 let done_chip = format!("✓ {} ", completed_at);
-                let ts_part = if let Some(ts) = time_spent {
-                    format!(" ⏱{}", ts)
-                } else {
-                    String::new()
+                let ts_part = {
+                    use crate::tasks::fmt_timedelta;
+                    fmt_timedelta(*time_spent)
+                        .map(|s| format!(" ⏱{}", s))
+                        .unwrap_or_default()
                 };
                 let suffix = format!("  {}", file_name);
                 let fixed_len = prefix.chars().count()

--- a/src/bin/patto-preview-tui/ui.rs
+++ b/src/bin/patto-preview-tui/ui.rs
@@ -1026,7 +1026,9 @@ fn draw_active_task_overlay(frame: &mut Frame, content_area: Rect, app: &App) {
     let num_rows = tasks_to_show.len() as u16;
 
     // Width: up to 40% of content width, min 20 cols.
-    let max_w = (content_area.width * 40 / 100).max(20).min(content_area.width);
+    let max_w = (content_area.width * 40 / 100)
+        .max(20)
+        .min(content_area.width);
 
     // Position: bottom-right of content area, 1 row above the bottom edge.
     let x = content_area.x + content_area.width.saturating_sub(max_w);
@@ -1066,7 +1068,7 @@ fn draw_active_task_overlay(frame: &mut Frame, content_area: Rect, app: &App) {
                     .fg(Color::Black)
                     .bg(Color::Yellow)
                     .add_modifier(Modifier::BOLD),
-            Style::default().fg(Color::Yellow).bg(Color::Black),
+                Style::default().fg(Color::Yellow).bg(Color::Black),
             ),
             _ => continue,
         };
@@ -1263,9 +1265,9 @@ fn draw_tasks_upcoming_content(
                             .fg(Color::Black)
                             .bg(Color::Yellow)
                             .add_modifier(Modifier::BOLD),
-                        DeadlineCategory::Tomorrow => Style::default()
-                            .fg(Color::Black)
-                            .bg(Color::Cyan),
+                        DeadlineCategory::Tomorrow => {
+                            Style::default().fg(Color::Black).bg(Color::Cyan)
+                        }
                         _ => Style::default().fg(Color::DarkGray).bg(Color::Black),
                     }
                 };
@@ -1319,7 +1321,10 @@ fn draw_tasks_upcoming_content(
                     };
                     spans.push(Span::styled(tracking, tracking_style));
                 }
-                spans.push(Span::styled(suffix_str, Style::default().fg(Color::DarkGray)));
+                spans.push(Span::styled(
+                    suffix_str,
+                    Style::default().fg(Color::DarkGray),
+                ));
                 lines.push(Line::from(spans));
             }
         }
@@ -1415,8 +1420,10 @@ fn draw_tasks_review_content(
                 } else {
                     text.clone()
                 };
-                let row_text =
-                    format!("{}{}{}{}{}", prefix, done_chip, truncated_text, ts_part, suffix);
+                let row_text = format!(
+                    "{}{}{}{}{}",
+                    prefix, done_chip, truncated_text, ts_part, suffix
+                );
                 lines.push(Line::from(Span::styled(row_text, row_style)));
             }
         }

--- a/src/bin/patto-preview-tui/ui.rs
+++ b/src/bin/patto-preview-tui/ui.rs
@@ -39,6 +39,11 @@ pub(crate) fn draw(frame: &mut Frame, app: &mut App, root_dir: &Path) {
     draw_content(frame, chunks[1], app, root_dir);
     draw_status_bar(frame, chunks[2], app);
 
+    // Fidget-style active task overlay (when tasks panel is closed)
+    if !app.tasks.visible {
+        draw_active_task_overlay(frame, chunks[1], app);
+    }
+
     if app.backlinks.visible {
         draw_backlinks_popup(frame, app);
     }
@@ -1001,6 +1006,90 @@ fn draw_fullscreen_image(frame: &mut Frame, app: &mut App, root_dir: &Path, src:
     frame.render_widget(
         Paragraph::new(hint).style(Style::default().bg(Color::DarkGray)),
         chunks[1],
+    );
+}
+
+/// Fidget-style overlay showing active (Doing/Paused) tasks in the bottom-right corner
+/// of the content area. Only drawn when the tasks panel is closed.
+fn draw_active_task_overlay(frame: &mut Frame, content_area: Rect, app: &App) {
+    use crate::tasks::task_status_icon;
+    use patto::parser::TaskStatus;
+
+    let active = app.tasks.active_tasks();
+    if active.is_empty() {
+        return;
+    }
+
+    // Show at most 3 tasks.
+    let max_rows = 3usize;
+    let tasks_to_show: Vec<_> = active.iter().take(max_rows).collect();
+    let num_rows = tasks_to_show.len() as u16;
+
+    // Width: up to 40% of content width, min 20 cols.
+    let max_w = (content_area.width * 40 / 100).max(20).min(content_area.width);
+
+    // Position: bottom-right of content area, 1 row above the bottom edge.
+    let x = content_area.x + content_area.width.saturating_sub(max_w);
+    let y = content_area
+        .y
+        .saturating_add(content_area.height)
+        .saturating_sub(num_rows + 1);
+
+    // Clamp to content area
+    if y < content_area.y || content_area.height < num_rows + 1 {
+        return;
+    }
+
+    let overlay_area = Rect {
+        x,
+        y,
+        width: max_w,
+        height: num_rows,
+    };
+
+    let inner_w = max_w as usize;
+
+    let mut lines: Vec<Line> = Vec::new();
+    for (status, text) in &tasks_to_show {
+        let (annotation, ann_style, text_style) = match status {
+            TaskStatus::Doing => (
+                "◑ doing",
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+                Style::default().fg(Color::Cyan).bg(Color::Black),
+            ),
+            TaskStatus::Paused => (
+                "⏸ paused",
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            Style::default().fg(Color::Yellow).bg(Color::Black),
+            ),
+            _ => continue,
+        };
+
+        let ann_len = annotation.chars().count();
+        let space = 1usize; // gap between annotation and text
+        let text_max = inner_w.saturating_sub(ann_len + space + 1);
+        let truncated = if text.chars().count() > text_max {
+            let s: String = text.chars().take(text_max.saturating_sub(1)).collect();
+            format!("{}…", s)
+        } else {
+            text.clone()
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {} ", annotation), ann_style),
+            Span::styled(format!(" {}", truncated), text_style),
+        ]));
+    }
+
+    frame.render_widget(
+        Paragraph::new(lines).style(Style::default().bg(Color::Black)),
+        overlay_area,
     );
 }
 

--- a/src/bin/patto-preview-tui/ui.rs
+++ b/src/bin/patto-preview-tui/ui.rs
@@ -1105,9 +1105,13 @@ fn draw_tasks_panel(frame: &mut Frame, app: &mut App) {
                 file_name,
                 due_str,
                 category,
+                status,
+                time_spent,
+                started_at,
                 ..
             } => {
-                use crate::tasks::DeadlineCategory;
+                use crate::tasks::{task_status_icon, DeadlineCategory};
+                use patto::parser::TaskStatus;
                 let base_style = match category {
                     DeadlineCategory::Overdue => Style::default().fg(Color::Red),
                     DeadlineCategory::Today => Style::default().fg(Color::Yellow),
@@ -1119,16 +1123,36 @@ fn draw_tasks_panel(frame: &mut Frame, app: &mut App) {
                     base_style
                 };
 
-                // Format: "> [due] text  file" truncated to fit inner width
-                let prefix = if is_sel { "> " } else { "  " };
+                // Build rich row: "{icon} {text}  [{due}] [⏱ ts] [▶ sa]  {file}"
+                let icon = task_status_icon(status);
+                let prefix = if is_sel {
+                    format!(">{} ", icon)
+                } else {
+                    format!(" {} ", icon)
+                };
                 let date_part = if due_str.is_empty() {
                     String::new()
                 } else {
                     format!("[{}] ", due_str)
                 };
-                let suffix = format!(" {}", file_name);
+                // Time-tracking chips (only for doing/paused)
+                let tracking = match status {
+                    TaskStatus::Doing | TaskStatus::Paused => {
+                        let mut parts = String::new();
+                        if let Some(ts) = time_spent {
+                            parts.push_str(&format!(" ⏱{}", ts));
+                        }
+                        if let Some(sa) = started_at {
+                            parts.push_str(&format!(" ▶{}", sa));
+                        }
+                        parts
+                    }
+                    _ => String::new(),
+                };
+                let suffix = format!("  {}", file_name);
                 // Available space for task text
-                let fixed_len = prefix.len() + date_part.len() + suffix.len();
+                let fixed_len =
+                    prefix.chars().count() + date_part.chars().count() + tracking.chars().count() + suffix.chars().count();
                 let text_max = inner_width.saturating_sub(fixed_len);
                 let truncated_text = if text.chars().count() > text_max {
                     let s: String = text.chars().take(text_max.saturating_sub(1)).collect();
@@ -1136,7 +1160,8 @@ fn draw_tasks_panel(frame: &mut Frame, app: &mut App) {
                 } else {
                     text.clone()
                 };
-                let row_text = format!("{}{}{}{}", prefix, date_part, truncated_text, suffix);
+                let row_text =
+                    format!("{}{}{}{}{}", prefix, date_part, truncated_text, tracking, suffix);
                 lines.push(Line::from(Span::styled(row_text, row_style)));
             }
         }

--- a/src/bin/patto-preview-tui/ui.rs
+++ b/src/bin/patto-preview-tui/ui.rs
@@ -1005,6 +1005,8 @@ fn draw_fullscreen_image(frame: &mut Frame, app: &mut App, root_dir: &Path, src:
 }
 
 fn draw_tasks_panel(frame: &mut Frame, app: &mut App) {
+    use crate::tasks::TasksView;
+
     let content_area = {
         let full = frame.area();
         // Reserve top title bar (1 row) and bottom status bar (1 row).
@@ -1048,13 +1050,35 @@ fn draw_tasks_panel(frame: &mut Frame, app: &mut App) {
 
     let inner_width = area.width.saturating_sub(2) as usize; // inside borders
 
+    let is_review = app.tasks.view == TasksView::Review;
+    let title = if is_review {
+        " Tasks Review  [R:upcoming] "
+    } else {
+        " Tasks  [R:review] "
+    };
     let block = Block::default()
-        .title(" Tasks ")
+        .title(title)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Cyan));
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
+    let inner_h = inner.height as usize;
+
+    if is_review {
+        draw_tasks_review_content(frame, app, inner, inner_h, inner_width);
+    } else {
+        draw_tasks_upcoming_content(frame, app, inner, inner_h, inner_width);
+    }
+}
+
+fn draw_tasks_upcoming_content(
+    frame: &mut Frame,
+    app: &App,
+    inner: Rect,
+    inner_h: usize,
+    inner_width: usize,
+) {
     let selected = app.tasks.list_state.selected;
     let entries = &app.tasks.entries;
     let total = entries.len();
@@ -1068,7 +1092,6 @@ fn draw_tasks_panel(frame: &mut Frame, app: &mut App) {
     }
 
     // Simple manual scroll: ensure selected item is visible.
-    let inner_h = inner.height as usize;
     let scroll_offset = if let Some(sel) = selected {
         if sel >= inner_h {
             sel + 1 - inner_h
@@ -1151,8 +1174,10 @@ fn draw_tasks_panel(frame: &mut Frame, app: &mut App) {
                 };
                 let suffix = format!("  {}", file_name);
                 // Available space for task text
-                let fixed_len =
-                    prefix.chars().count() + date_part.chars().count() + tracking.chars().count() + suffix.chars().count();
+                let fixed_len = prefix.chars().count()
+                    + date_part.chars().count()
+                    + tracking.chars().count()
+                    + suffix.chars().count();
                 let text_max = inner_width.saturating_sub(fixed_len);
                 let truncated_text = if text.chars().count() > text_max {
                     let s: String = text.chars().take(text_max.saturating_sub(1)).collect();
@@ -1162,6 +1187,103 @@ fn draw_tasks_panel(frame: &mut Frame, app: &mut App) {
                 };
                 let row_text =
                     format!("{}{}{}{}{}", prefix, date_part, truncated_text, tracking, suffix);
+                lines.push(Line::from(Span::styled(row_text, row_style)));
+            }
+        }
+    }
+
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+fn draw_tasks_review_content(
+    frame: &mut Frame,
+    app: &App,
+    inner: Rect,
+    inner_h: usize,
+    inner_width: usize,
+) {
+    use crate::tasks::ReviewEntry;
+
+    let selected = app.tasks.review_list_state.selected;
+    let entries = &app.tasks.review_entries;
+    let total = entries.len();
+
+    if total == 0 {
+        frame.render_widget(
+            Paragraph::new("(no completed tasks)").style(Style::default().fg(Color::DarkGray)),
+            inner,
+        );
+        return;
+    }
+
+    // Simple manual scroll: ensure selected item is visible.
+    let scroll_offset = if let Some(sel) = selected {
+        if sel >= inner_h {
+            sel + 1 - inner_h
+        } else {
+            0
+        }
+    } else {
+        0
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, entry) in entries.iter().enumerate().skip(scroll_offset) {
+        if lines.len() >= inner_h {
+            break;
+        }
+        let is_sel = selected == Some(i);
+        match entry {
+            ReviewEntry::SectionHeader(title) => {
+                lines.push(Line::from(Span::styled(
+                    title.clone(),
+                    Style::default()
+                        .fg(Color::DarkGray)
+                        .add_modifier(Modifier::BOLD),
+                )));
+            }
+            ReviewEntry::Placeholder(msg) => {
+                lines.push(Line::from(Span::styled(
+                    msg.clone(),
+                    Style::default().fg(Color::DarkGray),
+                )));
+            }
+            ReviewEntry::ReviewItem {
+                text,
+                file_name,
+                completed_at,
+                time_spent,
+                ..
+            } => {
+                let base_style = Style::default().fg(Color::Green);
+                let row_style = if is_sel {
+                    base_style.add_modifier(Modifier::REVERSED)
+                } else {
+                    base_style
+                };
+
+                // Build row: "{>|space} ✓ {completed_at} {text} [⏱ ts]  {file}"
+                let prefix = if is_sel { "> " } else { "  " };
+                let done_chip = format!("✓ {} ", completed_at);
+                let ts_part = if let Some(ts) = time_spent {
+                    format!(" ⏱{}", ts)
+                } else {
+                    String::new()
+                };
+                let suffix = format!("  {}", file_name);
+                let fixed_len = prefix.chars().count()
+                    + done_chip.chars().count()
+                    + ts_part.chars().count()
+                    + suffix.chars().count();
+                let text_max = inner_width.saturating_sub(fixed_len);
+                let truncated_text = if text.chars().count() > text_max {
+                    let s: String = text.chars().take(text_max.saturating_sub(1)).collect();
+                    format!("{}…", s)
+                } else {
+                    text.clone()
+                };
+                let row_text =
+                    format!("{}{}{}{}{}", prefix, done_chip, truncated_text, ts_part, suffix);
                 lines.push(Line::from(Span::styled(row_text, row_style)));
             }
         }


### PR DESCRIPTION
## Summary

Brings `patto-preview-tui` to feature parity with the Lua/Neovim plugin ecosystem (trouble.nvim sources, fidget.nvim notifications).

## Changes (5 separate commits)

### Task status icons + time-tracking display
- `TaskEntry::TaskItem` gains `status`, `time_spent`, `started_at` fields extracted from `AstNode::Property::Task`
- Icons in each row: `○` todo · `◑` doing · `⏸` paused — matching `patto_tasks` trouble source
- For doing/paused tasks: `⏱ 1h30m` and `▶ HH:MM` chips appended, matching `current_task.lua` / fidget display

### Tasks Review panel (`R` to toggle)
- Press **`R`** inside the Tasks panel to toggle between **Upcoming** and **Review** views
- Review shows recently completed tasks grouped by recency: Today / Yesterday / This Week / Last Week / This Month / Older
- Mirrors `lua/trouble/sources/patto_tasks_review.lua` classification
- Uses `Repository::aggregate_completed_tasks` with matching date range (earlier of start-of-last-week, start-of-month → today)
- Separate navigation/selection state per view; panel title shows `[R:review]` / `[R:upcoming]` hint

### Fidget-style active task overlay
- Floating overlay in the bottom-right of the content area — mirrors fidget.nvim corner notifications from `lua/patto/current_task.lua`
- Shows up to 3 Doing/Paused tasks with colored badges: `◑ doing` (cyan) / `⏸ paused` (yellow)
- Task cache refreshed at startup and on every `FileChanged` event (no need to open the panel)

### Styled due-date chip
- Due date rendered as a colored background chip: red bg (overdue), yellow bg (today), cyan bg (tomorrow), dark gray text (others)
- Matches the `task_due` formatter in the trouble.nvim source
- File name and tracking chips dimmed for better visual hierarchy
- Multi-span `Line` rendering replaces flat string formatting

### Total elapsed time for Doing tasks (mirrors PR #103 / 57e11b8)
- `⏱` chip now shows **total = accumulated `time_spent` + live elapsed since `started_at`** for Doing tasks
- For Paused/Todo tasks (no active session), only the stored `time_spent` is shown
- A 60-second `tokio::time::interval` in `main.rs` wakes the render loop periodically so the counter stays live on screen — equivalent to `display_interval` in `current_task.lua` and the refresh timer in `patto_tasks.lua`