### PR TITLE
feat(tui): preview inline math in TUI

### DIFF
--- a/src/bin/patto-preview-tui/app.rs
+++ b/src/bin/patto-preview-tui/app.rs
@@ -75,6 +75,8 @@ pub(crate) struct App {
     pub(crate) tui_config: config::TuiConfig,
     /// syntect theme name for code block syntax highlighting.
     pub(crate) syntax_theme: String,
+    /// Whether to render inline math as raster images. Loaded from config.
+    pub(crate) inline_math_rendering: bool,
     /// Active incremental search state. `None` when no search is active.
     pub(crate) search: Option<SearchState>,
 }
@@ -107,6 +109,7 @@ impl App {
             task_preview_state: None,
             tui_config: config::TuiConfig::default(),
             syntax_theme: String::new(),
+            inline_math_rendering: true,
             search: None,
         }
     }
@@ -169,7 +172,11 @@ impl App {
     pub(crate) fn re_render(&mut self, content: &str) {
         let result =
             parser::parse_text_with_persistent_line_tracking(content, &mut self.line_tracker);
-        self.rendered_doc = tui_renderer::render_ast(&result.ast, Some(self.syntax_theme.as_str()));
+        self.rendered_doc = tui_renderer::render_ast(
+            &result.ast,
+            Some(self.syntax_theme.as_str()),
+            self.inline_math_rendering,
+        );
     }
 
     /// Return a reference to the currently focused item, if any.
@@ -375,7 +382,10 @@ impl App {
                 return;
             }
             let h = self.elem_display_height(elem);
-            if let DocElement::TextLine(_, _) = elem {
+            if matches!(
+                elem,
+                DocElement::TextLine(_, _) | DocElement::InlineMathLine { .. }
+            ) {
                 current_source_line += 1;
             }
             row += h;
@@ -389,8 +399,13 @@ impl App {
         let target_row = line.saturating_sub(1); // convert to 0-indexed
         let mut display_row = 0usize;
         for elem in &self.rendered_doc.elements {
-            if let DocElement::TextLine(_, source_row) = elem {
-                if *source_row >= target_row {
+            let source_row = match elem {
+                DocElement::TextLine(_, r) => Some(*r),
+                DocElement::InlineMathLine { source_row, .. } => Some(*source_row),
+                _ => None,
+            };
+            if let Some(r) = source_row {
+                if r >= target_row {
                     self.scroll_offset = display_row;
                     return;
                 }
@@ -409,8 +424,10 @@ impl App {
             if display_row > self.scroll_offset {
                 break;
             }
-            if let DocElement::TextLine(_, source_row) = elem {
-                last_source_row = *source_row;
+            match elem {
+                DocElement::TextLine(_, source_row) => last_source_row = *source_row,
+                DocElement::InlineMathLine { source_row, .. } => last_source_row = *source_row,
+                _ => {}
             }
             display_row += self.elem_display_height(elem);
         }
@@ -421,12 +438,10 @@ impl App {
     /// or `None` if nothing is focused. Used for `{line}` in editor commands.
     pub(crate) fn source_line_of_focused_item(&self) -> Option<usize> {
         let fi = self.focused_item()?;
-        if let Some(DocElement::TextLine(_, source_row)) =
-            self.rendered_doc.elements.get(fi.elem_idx)
-        {
-            Some(source_row + 1)
-        } else {
-            None
+        match self.rendered_doc.elements.get(fi.elem_idx) {
+            Some(DocElement::TextLine(_, source_row)) => Some(source_row + 1),
+            Some(DocElement::InlineMathLine { source_row, .. }) => Some(source_row + 1),
+            _ => None,
         }
     }
 

--- a/src/bin/patto-preview-tui/app.rs
+++ b/src/bin/patto-preview-tui/app.rs
@@ -134,8 +134,7 @@ impl App {
             elem,
             self.wrap_config().as_ref(),
             self.images.height_rows,
-            Some(&self.images.elem_heights),
-            Some(&self.images.elem_widths),
+            Some(&self.images.elem_sizes),
         )
     }
 
@@ -145,8 +144,7 @@ impl App {
             &self.rendered_doc.elements,
             self.wrap_config().as_ref(),
             self.images.height_rows,
-            Some(&self.images.elem_heights),
-            Some(&self.images.elem_widths),
+            Some(&self.images.elem_sizes),
         )
     }
 
@@ -174,11 +172,11 @@ impl App {
     pub(crate) fn re_render(&mut self, content: &str) {
         let result =
             parser::parse_text_with_persistent_line_tracking(content, &mut self.line_tracker);
-        self.rendered_doc = tui_renderer::render_ast(
-            &result.ast,
-            Some(self.syntax_theme.as_str()),
-            self.inline_math_rendering,
-        );
+        let cfg = tui_renderer::RenderConfig {
+            syntax_theme: Some(self.syntax_theme.as_str()),
+            inline_math: self.inline_math_rendering,
+        };
+        self.rendered_doc = tui_renderer::render_ast(&result.ast, &cfg);
     }
 
     /// Return a reference to the currently focused item, if any.

--- a/src/bin/patto-preview-tui/app.rs
+++ b/src/bin/patto-preview-tui/app.rs
@@ -135,6 +135,7 @@ impl App {
             self.wrap_config().as_ref(),
             self.images.height_rows,
             Some(&self.images.elem_heights),
+            Some(&self.images.elem_widths),
         )
     }
 
@@ -145,6 +146,7 @@ impl App {
             self.wrap_config().as_ref(),
             self.images.height_rows,
             Some(&self.images.elem_heights),
+            Some(&self.images.elem_widths),
         )
     }
 

--- a/src/bin/patto-preview-tui/config.rs
+++ b/src/bin/patto-preview-tui/config.rs
@@ -121,6 +121,10 @@ fn default_syntax_theme() -> String {
     "base16-ocean.dark".to_string()
 }
 
+fn default_true() -> bool {
+    true
+}
+
 /// Top-level TUI configuration (`~/.config/patto/patto-preview-tui.toml`).
 #[derive(Debug, Deserialize)]
 pub struct TuiConfig {
@@ -138,6 +142,11 @@ pub struct TuiConfig {
     /// Defaults to `"white"`.
     #[serde(default)]
     pub image_background: ImageBackground,
+    /// Whether to render inline math (`[$ … $]`) as raster images.
+    /// When `false`, inline math is displayed as plain magenta text instead.
+    /// Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub inline_math_rendering: bool,
 }
 
 impl Default for TuiConfig {
@@ -147,6 +156,7 @@ impl Default for TuiConfig {
             syntax_theme: default_syntax_theme(),
             tasks: TasksPanelConfig::default(),
             image_background: ImageBackground::default(),
+            inline_math_rendering: true,
         }
     }
 }

--- a/src/bin/patto-preview-tui/image_cache.rs
+++ b/src/bin/patto-preview-tui/image_cache.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::math_render;
+use crate::wrap::ElemSizeCache;
 
 pub(crate) enum CachedImage {
     Loaded(StatefulProtocol),
@@ -45,11 +46,8 @@ pub(crate) struct ImageCache {
     picker: Option<Picker>,
     /// Default image height in terminal rows (user-configurable via +/-).
     pub(crate) height_rows: u16,
-    /// Per-element row heights keyed by cache key (image src or math content).
-    /// Images store `height_rows`; math stores the tight pixel-computed height.
-    pub(crate) elem_heights: HashMap<String, u16>,
-    /// Column widths for inline math images (cache key → terminal columns).
-    pub(crate) elem_widths: HashMap<String, u16>,
+    /// Cached element sizes (heights and widths) for images and math.
+    pub(crate) elem_sizes: ElemSizeCache,
     /// Source of the image currently shown fullscreen (None = normal view).
     pub(crate) fullscreen_src: Option<String>,
     /// RGB background used when compositing images with transparency.
@@ -82,8 +80,7 @@ impl ImageCache {
             cache: HashMap::new(),
             picker,
             height_rows: 10,
-            elem_heights: HashMap::new(),
-            elem_widths: HashMap::new(),
+            elem_sizes: ElemSizeCache::default(),
             fullscreen_src: None,
             background_color: Some([255, 255, 255]),
         }
@@ -105,7 +102,7 @@ impl ImageCache {
                                 img
                             };
                             let protocol = self.picker.as_mut().unwrap().new_resize_protocol(img);
-                            self.elem_heights.insert(src.to_string(), self.height_rows);
+                            self.elem_sizes.heights.insert(src.to_string(), self.height_rows);
                             self.cache
                                 .insert(src.to_string(), CachedImage::Loaded(protocol));
                         }
@@ -143,7 +140,7 @@ impl ImageCache {
                     img
                 };
                 let protocol = self.picker.as_mut().unwrap().new_resize_protocol(img);
-                self.elem_heights.insert(src.to_string(), self.height_rows);
+                self.elem_sizes.heights.insert(src.to_string(), self.height_rows);
                 self.cache
                     .insert(src.to_string(), CachedImage::Loaded(protocol));
             }
@@ -162,8 +159,7 @@ impl ImageCache {
     /// Clear all cached images and their stored heights.
     pub(crate) fn clear(&mut self) {
         self.cache.clear();
-        self.elem_heights.clear();
-        self.elem_widths.clear();
+        self.elem_sizes.clear();
     }
 
     pub(crate) fn increase_height(&mut self) {
@@ -184,7 +180,7 @@ impl ImageCache {
         if self.cache.contains_key(content) || self.picker.is_none() {
             return;
         }
-        match math_render::render_latex_to_image(content) {
+        match math_render::render_latex(content, math_render::MathStyle::Display) {
             Ok(img) => {
                 // Compute the exact terminal rows this image occupies so we
                 // can allocate a tight rect (no blank padding below the formula).
@@ -194,7 +190,7 @@ impl ImageCache {
                 } else {
                     self.height_rows
                 };
-                self.elem_heights.insert(content.to_string(), rows_needed);
+                self.elem_sizes.heights.insert(content.to_string(), rows_needed);
                 let protocol = self.picker.as_mut().unwrap().new_resize_protocol(img);
                 self.cache
                     .insert(content.to_string(), CachedImage::Loaded(protocol));
@@ -224,7 +220,7 @@ impl ImageCache {
         let (cell_w, cell_h) = self.picker.as_ref().unwrap().font_size();
         let cell_width_px = if cell_w > 0 { cell_w as u32 } else { 10 };
 
-        match math_render::render_latex_inline(content) {
+        match math_render::render_latex(content, math_render::MathStyle::Inline) {
             Ok(img) => {
                 // Compute natural row height (same logic as load_math).
                 let rows_needed = if cell_h > 0 {
@@ -232,10 +228,10 @@ impl ImageCache {
                 } else {
                     2 // safe fallback for fractions
                 };
-                self.elem_heights.insert(key.clone(), rows_needed);
+                self.elem_sizes.heights.insert(key.clone(), rows_needed);
                 // Width in terminal columns (round up).
                 let cols = ((img.width() as f32 / cell_width_px as f32).ceil() as u16).max(1);
-                self.elem_widths.insert(key.clone(), cols);
+                self.elem_sizes.widths.insert(key.clone(), cols);
                 let protocol = self.picker.as_mut().unwrap().new_resize_protocol(img);
                 self.cache.insert(key, CachedImage::Loaded(protocol));
             }
@@ -248,6 +244,6 @@ impl ImageCache {
     /// Return the column width of a cached inline math image, if available.
     pub(crate) fn inline_math_cols(&self, content: &str) -> Option<u16> {
         let key = Self::inline_math_key(content);
-        self.elem_widths.get(&key).copied()
+        self.elem_sizes.widths.get(&key).copied()
     }
 }

--- a/src/bin/patto-preview-tui/image_cache.rs
+++ b/src/bin/patto-preview-tui/image_cache.rs
@@ -102,7 +102,9 @@ impl ImageCache {
                                 img
                             };
                             let protocol = self.picker.as_mut().unwrap().new_resize_protocol(img);
-                            self.elem_sizes.heights.insert(src.to_string(), self.height_rows);
+                            self.elem_sizes
+                                .heights
+                                .insert(src.to_string(), self.height_rows);
                             self.cache
                                 .insert(src.to_string(), CachedImage::Loaded(protocol));
                         }
@@ -140,7 +142,9 @@ impl ImageCache {
                     img
                 };
                 let protocol = self.picker.as_mut().unwrap().new_resize_protocol(img);
-                self.elem_sizes.heights.insert(src.to_string(), self.height_rows);
+                self.elem_sizes
+                    .heights
+                    .insert(src.to_string(), self.height_rows);
                 self.cache
                     .insert(src.to_string(), CachedImage::Loaded(protocol));
             }
@@ -190,7 +194,9 @@ impl ImageCache {
                 } else {
                     self.height_rows
                 };
-                self.elem_sizes.heights.insert(content.to_string(), rows_needed);
+                self.elem_sizes
+                    .heights
+                    .insert(content.to_string(), rows_needed);
                 let protocol = self.picker.as_mut().unwrap().new_resize_protocol(img);
                 self.cache
                     .insert(content.to_string(), CachedImage::Loaded(protocol));

--- a/src/bin/patto-preview-tui/image_cache.rs
+++ b/src/bin/patto-preview-tui/image_cache.rs
@@ -48,6 +48,8 @@ pub(crate) struct ImageCache {
     /// Per-element row heights keyed by cache key (image src or math content).
     /// Images store `height_rows`; math stores the tight pixel-computed height.
     pub(crate) elem_heights: HashMap<String, u16>,
+    /// Column widths for inline math images (cache key → terminal columns).
+    pub(crate) elem_widths: HashMap<String, u16>,
     /// Source of the image currently shown fullscreen (None = normal view).
     pub(crate) fullscreen_src: Option<String>,
     /// RGB background used when compositing images with transparency.
@@ -81,6 +83,7 @@ impl ImageCache {
             picker,
             height_rows: 10,
             elem_heights: HashMap::new(),
+            elem_widths: HashMap::new(),
             fullscreen_src: None,
             background_color: Some([255, 255, 255]),
         }
@@ -160,6 +163,7 @@ impl ImageCache {
     pub(crate) fn clear(&mut self) {
         self.cache.clear();
         self.elem_heights.clear();
+        self.elem_widths.clear();
     }
 
     pub(crate) fn increase_height(&mut self) {
@@ -200,5 +204,50 @@ impl ImageCache {
                     .insert(content.to_string(), CachedImage::Failed(e));
             }
         }
+    }
+
+    /// Cache key prefix for inline math entries.
+    pub(crate) fn inline_math_key(content: &str) -> String {
+        format!("__inline__:{}", content)
+    }
+
+    /// Render an inline LaTeX math expression to an image and cache it.
+    ///
+    /// Uses Typst inline/text math style so fractions are compact but readable.
+    /// The cache key is `"__inline__:{content}"`. Does nothing when there is no
+    /// image protocol picker (text-only terminal).
+    pub(crate) fn load_inline_math(&mut self, content: &str) {
+        let key = Self::inline_math_key(content);
+        if self.cache.contains_key(&key) || self.picker.is_none() {
+            return;
+        }
+        let (cell_w, cell_h) = self.picker.as_ref().unwrap().font_size();
+        let cell_width_px = if cell_w > 0 { cell_w as u32 } else { 10 };
+
+        match math_render::render_latex_inline(content) {
+            Ok(img) => {
+                // Compute natural row height (same logic as load_math).
+                let rows_needed = if cell_h > 0 {
+                    ((img.height() as f32 / cell_h as f32).ceil() as u16).max(1)
+                } else {
+                    2 // safe fallback for fractions
+                };
+                self.elem_heights.insert(key.clone(), rows_needed);
+                // Width in terminal columns (round up).
+                let cols = ((img.width() as f32 / cell_width_px as f32).ceil() as u16).max(1);
+                self.elem_widths.insert(key.clone(), cols);
+                let protocol = self.picker.as_mut().unwrap().new_resize_protocol(img);
+                self.cache.insert(key, CachedImage::Loaded(protocol));
+            }
+            Err(e) => {
+                self.cache.insert(key, CachedImage::Failed(e));
+            }
+        }
+    }
+
+    /// Return the column width of a cached inline math image, if available.
+    pub(crate) fn inline_math_cols(&self, content: &str) -> Option<u16> {
+        let key = Self::inline_math_key(content);
+        self.elem_widths.get(&key).copied()
     }
 }

--- a/src/bin/patto-preview-tui/image_cache.rs
+++ b/src/bin/patto-preview-tui/image_cache.rs
@@ -1,4 +1,4 @@
-use image::{DynamicImage, GenericImage, GenericImageView, Rgba};
+use image::{DynamicImage, Rgba};
 use ratatui_image::{
     picker::{Picker, ProtocolType},
     protocol::StatefulProtocol,

--- a/src/bin/patto-preview-tui/main.rs
+++ b/src/bin/patto-preview-tui/main.rs
@@ -258,6 +258,7 @@ async fn main() -> anyhow::Result<()> {
     let tui_config = config::TuiConfig::load();
     app.syntax_theme = tui_config.syntax_theme.clone();
     app.images.background_color = tui_config.image_background.to_rgb();
+    app.inline_math_rendering = tui_config.inline_math_rendering;
     app.tui_config = tui_config;
     app.re_render(&initial_content);
 

--- a/src/bin/patto-preview-tui/math_render.rs
+++ b/src/bin/patto-preview-tui/math_render.rs
@@ -1,8 +1,8 @@
 //! Math rendering: LaTeX/Typst → raster image via the embedded Typst compiler.
 //!
 //! Public API:
-//!  - [`render_typst_to_image`]: renders a Typst math expression (already in Typst syntax)
-//!  - [`render_latex_to_image`]: converts LaTeX → Typst via `tex2typst-rs`, then delegates
+//!  - [`render_typst`]: renders a Typst math expression to an image
+//!  - [`render_latex`]: converts LaTeX → Typst via `tex2typst-rs`, then delegates
 
 use image::DynamicImage;
 use std::sync::OnceLock;
@@ -17,13 +17,19 @@ use typst::LibraryExt;
 use typst::World;
 use typst_kit::fonts::{FontSearcher, Fonts};
 
+/// Whether to render in display (block) or inline (text) math style.
+pub enum MathStyle {
+    /// Display style: `$ formula $` — large operators, tall fractions.
+    Display,
+    /// Inline/text style: `$formula$` — compact fractions, smaller scripts.
+    Inline,
+}
+
 static MATH_FONTS: OnceLock<Fonts> = OnceLock::new();
 
 fn get_math_fonts() -> &'static Fonts {
     MATH_FONTS.get_or_init(|| {
         let mut searcher = FontSearcher::new();
-        // Only use embedded fonts — avoids scanning the system and makes the
-        // binary fully self-contained (New Computer Modern Math is embedded).
         searcher.include_system_fonts(false);
         searcher.search()
     })
@@ -82,17 +88,29 @@ impl World for MathWorld {
     }
 }
 
-/// Render a Typst math expression (in Typst syntax) to a raster image.
+/// Render a Typst math expression to a raster image.
 ///
 /// `typst_math` should be valid Typst math content, e.g. `sum_(i=0)^n x_i`.
 /// The expression is embedded in a minimal dark-background Typst document and
 /// rendered at 2× scale for crispness.
-pub fn render_typst_to_image(typst_math: &str) -> Result<DynamicImage, String> {
+///
+/// - [`MathStyle::Display`]: `$ formula $` — full-size operators/fractions.
+/// - [`MathStyle::Inline`]: `$formula$` — compact text-style rendering.
+pub fn render_typst(typst_math: &str, style: MathStyle) -> Result<DynamicImage, String> {
+    let (margins, math_expr) = match style {
+        MathStyle::Display => (
+            "top: 4pt, bottom: 2pt, left: 4pt, right: 4pt",
+            format!("$ {} $", typst_math),
+        ),
+        MathStyle::Inline => (
+            "top: 2pt, bottom: 4pt, left: 3pt, right: 3pt",
+            format!("${typst_math}$"),
+        ),
+    };
     let source_text = format!(
-        "#set page(width: auto, height: auto, margin: (top: 4pt, bottom: 2pt, left: 4pt, right: 4pt), fill: black)\n\
+        "#set page(width: auto, height: auto, margin: ({margins}), fill: black)\n\
          #set text(fill: white, size: 14pt)\n\
-         $ {} $\n",
-        typst_math
+         {math_expr}\n"
     );
 
     let world = MathWorld::new(source_text);
@@ -122,60 +140,9 @@ pub fn render_typst_to_image(typst_math: &str) -> Result<DynamicImage, String> {
 /// Render a LaTeX math expression to a raster image.
 ///
 /// Converts LaTeX → Typst math via `tex2typst-rs`, then delegates to
-/// [`render_typst_to_image`]. This split enables future callers to pass
-/// native Typst math directly without going through the converter.
-pub fn render_latex_to_image(latex: &str) -> Result<DynamicImage, String> {
+/// [`render_typst`].
+pub fn render_latex(latex: &str, style: MathStyle) -> Result<DynamicImage, String> {
     let typst_math =
         tex2typst_rs::tex2typst(latex).map_err(|e| format!("tex2typst conversion failed: {e}"))?;
-    render_typst_to_image(&typst_math)
-}
-
-/// Render a LaTeX math expression as a compact inline image.
-///
-/// Uses Typst's inline math style (`$formula$`, no surrounding spaces) which
-/// renders fractions and operators in "text style" -- compact but readable,
-/// matching how LaTeX typesets `$\frac{a}{b}$` in prose.
-///
-/// Font size is the same as block math (14pt); the image height is determined
-/// naturally by the expression, typically 1 row for simple expressions and
-/// 2 rows for fractions.
-pub fn render_latex_inline(latex: &str) -> Result<DynamicImage, String> {
-    let typst_math =
-        tex2typst_rs::tex2typst(latex).map_err(|e| format!("tex2typst conversion failed: {e}"))?;
-    render_typst_inline(&typst_math)
-}
-
-/// Render a Typst math expression in inline (text) style.
-///
-/// Uses `$formula$` (no spaces) so Typst renders in text/inline math mode:
-/// compact fractions, smaller sub/superscripts.  14pt font, 2x scale.
-pub fn render_typst_inline(typst_math: &str) -> Result<DynamicImage, String> {
-    let source_text = format!(
-        "#set page(width: auto, height: auto, margin: (top: 2pt, bottom: 4pt, left: 3pt, right: 3pt), fill: black)\n\
-         #set text(fill: white, size: 14pt)\n\
-         ${typst_math}$\n"
-    );
-
-    let world = MathWorld::new(source_text);
-    let document = typst::compile::<PagedDocument>(&world)
-        .output
-        .map_err(|errors| {
-            errors
-                .iter()
-                .map(|e| e.message.to_string())
-                .collect::<Vec<_>>()
-                .join("; ")
-        })?;
-
-    let page = document
-        .pages
-        .first()
-        .ok_or_else(|| "Typst produced no pages".to_string())?;
-
-    let pixmap = typst_render::render(page, 2.0);
-    let png_bytes = pixmap
-        .encode_png()
-        .map_err(|e| format!("PNG encode error: {e}"))?;
-
-    image::load_from_memory(&png_bytes).map_err(|e| format!("image decode error: {e}"))
+    render_typst(&typst_math, style)
 }

--- a/src/bin/patto-preview-tui/math_render.rs
+++ b/src/bin/patto-preview-tui/math_render.rs
@@ -151,7 +151,7 @@ pub fn render_latex_inline(latex: &str) -> Result<DynamicImage, String> {
 /// compact fractions, smaller sub/superscripts.  14pt font, 2x scale.
 pub fn render_typst_inline(typst_math: &str) -> Result<DynamicImage, String> {
     let source_text = format!(
-        "#set page(width: auto, height: auto, margin: (top: 2pt, bottom: 2pt, left: 3pt, right: 3pt), fill: black)\n\
+        "#set page(width: auto, height: auto, margin: (top: 2pt, bottom: 4pt, left: 3pt, right: 3pt), fill: black)\n\
          #set text(fill: white, size: 14pt)\n\
          ${typst_math}$\n"
     );

--- a/src/bin/patto-preview-tui/math_render.rs
+++ b/src/bin/patto-preview-tui/math_render.rs
@@ -129,3 +129,53 @@ pub fn render_latex_to_image(latex: &str) -> Result<DynamicImage, String> {
         tex2typst_rs::tex2typst(latex).map_err(|e| format!("tex2typst conversion failed: {e}"))?;
     render_typst_to_image(&typst_math)
 }
+
+/// Render a LaTeX math expression as a compact inline image.
+///
+/// Uses Typst's inline math style (`$formula$`, no surrounding spaces) which
+/// renders fractions and operators in "text style" -- compact but readable,
+/// matching how LaTeX typesets `$\frac{a}{b}$` in prose.
+///
+/// Font size is the same as block math (14pt); the image height is determined
+/// naturally by the expression, typically 1 row for simple expressions and
+/// 2 rows for fractions.
+pub fn render_latex_inline(latex: &str) -> Result<DynamicImage, String> {
+    let typst_math =
+        tex2typst_rs::tex2typst(latex).map_err(|e| format!("tex2typst conversion failed: {e}"))?;
+    render_typst_inline(&typst_math)
+}
+
+/// Render a Typst math expression in inline (text) style.
+///
+/// Uses `$formula$` (no spaces) so Typst renders in text/inline math mode:
+/// compact fractions, smaller sub/superscripts.  14pt font, 2x scale.
+pub fn render_typst_inline(typst_math: &str) -> Result<DynamicImage, String> {
+    let source_text = format!(
+        "#set page(width: auto, height: auto, margin: (top: 2pt, bottom: 2pt, left: 3pt, right: 3pt), fill: black)\n\
+         #set text(fill: white, size: 14pt)\n\
+         ${typst_math}$\n"
+    );
+
+    let world = MathWorld::new(source_text);
+    let document = typst::compile::<PagedDocument>(&world)
+        .output
+        .map_err(|errors| {
+            errors
+                .iter()
+                .map(|e| e.message.to_string())
+                .collect::<Vec<_>>()
+                .join("; ")
+        })?;
+
+    let page = document
+        .pages
+        .first()
+        .ok_or_else(|| "Typst produced no pages".to_string())?;
+
+    let pixmap = typst_render::render(page, 2.0);
+    let png_bytes = pixmap
+        .encode_png()
+        .map_err(|e| format!("PNG encode error: {e}"))?;
+
+    image::load_from_memory(&png_bytes).map_err(|e| format!("image decode error: {e}"))
+}

--- a/src/bin/patto-preview-tui/ui.rs
+++ b/src/bin/patto-preview-tui/ui.rs
@@ -353,16 +353,12 @@ fn draw_inline_math_line(
                 let mut row_x_start = x_cursor;
                 let mut sub_spans: Vec<Span<'static>> = Vec::new();
                 let mut cur_buf = String::new();
-                let mut cur_style: Style =
-                    spans.first().map(|s| s.style).unwrap_or_default();
+                let mut cur_style: Style = spans.first().map(|s| s.style).unwrap_or_default();
 
                 for span in spans {
                     if span.style != cur_style {
                         if !cur_buf.is_empty() {
-                            sub_spans.push(Span::styled(
-                                std::mem::take(&mut cur_buf),
-                                cur_style,
-                            ));
+                            sub_spans.push(Span::styled(std::mem::take(&mut cur_buf), cur_style));
                         }
                         cur_style = span.style;
                     }
@@ -370,27 +366,21 @@ fn draw_inline_math_line(
                         let ch_w = UnicodeWidthChar::width(ch).unwrap_or(0) as u16;
                         if wrap
                             && col_width > 0
-                            && (x_cursor as usize + ch_w as usize)
-                                > (area.x as usize + col_width)
+                            && (x_cursor as usize + ch_w as usize) > (area.x as usize + col_width)
                         {
                             // Flush accumulated text to the current row.
                             if !cur_buf.is_empty() {
-                                sub_spans.push(Span::styled(
-                                    std::mem::take(&mut cur_buf),
-                                    cur_style,
-                                ));
+                                sub_spans
+                                    .push(Span::styled(std::mem::take(&mut cur_buf), cur_style));
                             }
                             if !sub_spans.is_empty() {
-                                let text_y =
-                                    area.y + y as u16 + row_offset + cur_row_h / 2;
+                                let text_y = area.y + y as u16 + row_offset + cur_row_h / 2;
                                 let sub_w = x_cursor.saturating_sub(row_x_start);
-                                let avail_rows = (height as u16)
-                                    .saturating_sub(y as u16 + row_offset);
+                                let avail_rows =
+                                    (height as u16).saturating_sub(y as u16 + row_offset);
                                 if sub_w > 0 && avail_rows > 0 {
                                     frame.render_widget(
-                                        Paragraph::new(Line::from(std::mem::take(
-                                            &mut sub_spans,
-                                        ))),
+                                        Paragraph::new(Line::from(std::mem::take(&mut sub_spans))),
                                         Rect::new(row_x_start, text_y, sub_w, 1),
                                     );
                                 } else {
@@ -414,8 +404,7 @@ fn draw_inline_math_line(
                 if !sub_spans.is_empty() {
                     let text_y = area.y + y as u16 + row_offset + cur_row_h / 2;
                     let sub_w = x_cursor.saturating_sub(row_x_start);
-                    let avail_rows =
-                        (height as u16).saturating_sub(y as u16 + row_offset);
+                    let avail_rows = (height as u16).saturating_sub(y as u16 + row_offset);
                     if sub_w > 0 && avail_rows > 0 {
                         frame.render_widget(
                             Paragraph::new(Line::from(sub_spans)),
@@ -438,8 +427,7 @@ fn draw_inline_math_line(
                 if wrap
                     && col_width > 0
                     && x_cursor > area.x
-                    && (x_cursor as usize + seg_w as usize)
-                        > (area.x as usize + col_width)
+                    && (x_cursor as usize + seg_w as usize) > (area.x as usize + col_width)
                 {
                     row_offset += cur_row_h;
                     x_cursor = area.x;
@@ -450,8 +438,7 @@ fn draw_inline_math_line(
 
                 let avail_x = max_x.saturating_sub(x_cursor);
                 let w = (seg_w as u16).min(avail_x);
-                let avail_rows =
-                    (height as u16).saturating_sub(y as u16 + row_offset);
+                let avail_rows = (height as u16).saturating_sub(y as u16 + row_offset);
                 let h = seg_h.min(avail_rows).max(1);
                 let base_y = area.y + y as u16 + row_offset;
 
@@ -459,9 +446,7 @@ fn draw_inline_math_line(
                     let math_area = Rect::new(x_cursor, base_y, w, h);
                     match images.get_mut(&key) {
                         Some(_) => {
-                            draw_image_cell(
-                                frame, images, &key, None, math_area, false,
-                            );
+                            draw_image_cell(frame, images, &key, None, math_area, false);
                         }
                         None => {
                             frame.render_widget(
@@ -653,8 +638,7 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
                 y += 1;
             }
             DocElement::Image { src, alt, indent } => {
-                let elem_h =
-                    (elem_height(elem, None, img_h, None) as u16).min((height - y) as u16);
+                let elem_h = (elem_height(elem, None, img_h, None) as u16).min((height - y) as u16);
                 let indent_w = (*indent as u16) * 2;
                 let img_area = Rect::new(
                     area.x + indent_w,
@@ -674,8 +658,7 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
             }
             DocElement::ImageRow(images, indent) => {
                 let n = images.len() as u16;
-                let elem_h =
-                    (elem_height(elem, None, img_h, None) as u16).min((height - y) as u16);
+                let elem_h = (elem_height(elem, None, img_h, None) as u16).min((height - y) as u16);
                 let indent_w = (*indent as u16) * 2;
                 let row_width = area.width.saturating_sub(indent_w);
                 let col_w = row_width / n;
@@ -711,10 +694,8 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
                 y += elem_h as usize;
             }
             DocElement::Math { content, indent } => {
-                let elem_h =
-                    (elem_height(elem, None, img_h, Some(&elem_sizes))
-                        as u16)
-                        .min((height - y) as u16);
+                let elem_h = (elem_height(elem, None, img_h, Some(&elem_sizes)) as u16)
+                    .min((height - y) as u16);
                 let indent_w = (*indent as u16) * 2;
                 let math_area = Rect::new(
                     area.x + indent_w,
@@ -754,10 +735,7 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
             }
             DocElement::InlineMathLine { segments, .. } => {
                 let elem_total_h = elem_h(elem) as u16;
-                draw_inline_math_line(
-                    frame, segments, area, y, height, wrap,
-                    &mut app.images,
-                );
+                draw_inline_math_line(frame, segments, area, y, height, wrap, &mut app.images);
                 y += elem_total_h as usize;
             }
         }

--- a/src/bin/patto-preview-tui/ui.rs
+++ b/src/bin/patto-preview-tui/ui.rs
@@ -13,7 +13,7 @@ use ratatui::{
 use ratatui_image::StatefulImage;
 use std::path::Path;
 use tui_widget_list::{ListBuilder, ListView};
-use unicode_width::UnicodeWidthStr;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::app::App;
 use crate::image_cache::CachedImage;
@@ -66,6 +66,7 @@ fn draw_title_bar(frame: &mut Frame, area: Rect, app: &App) {
         app.wrap_config().as_ref(),
         app.images.height_rows,
         Some(&app.images.elem_heights),
+        Some(&app.images.elem_widths),
     );
     let (pos, pct) = if total > 0 {
         let p = ((app.scroll_offset + 1) * 100 / total).min(100);
@@ -334,9 +335,10 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
     let img_h = app.images.height_rows;
     let wrap = app.wrap;
     let showbreak = app.showbreak.clone();
-    // Snapshot elem_heights so the closure doesn't hold a borrow on app.images
-    // while we later call app.images.load() / load_math() mutably.
+    // Snapshot elem_heights/elem_widths so the closure doesn't hold a borrow on
+    // app.images while we later call app.images.load() / load_math() mutably.
     let elem_heights = app.images.elem_heights.clone();
+    let elem_widths = app.images.elem_widths.clone();
     // Update viewport dimensions (used by wrap-aware scroll calculations)
     app.viewport_width = area.width;
     app.viewport_height = height;
@@ -351,7 +353,13 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
         } else {
             None
         };
-        elem_height(elem, cfg_opt, img_h, Some(&elem_heights))
+        elem_height(
+            elem,
+            cfg_opt,
+            img_h,
+            Some(&elem_heights),
+            Some(&elem_widths),
+        )
     };
 
     // Skip elements until we reach scroll_offset rows
@@ -560,7 +568,8 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
                 y += 1;
             }
             DocElement::Image { src, alt, indent } => {
-                let elem_h = (elem_height(elem, None, img_h, None) as u16).min((height - y) as u16);
+                let elem_h =
+                    (elem_height(elem, None, img_h, None, None) as u16).min((height - y) as u16);
                 let indent_w = (*indent as u16) * 2;
                 let img_area = Rect::new(
                     area.x + indent_w,
@@ -580,7 +589,8 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
             }
             DocElement::ImageRow(images, indent) => {
                 let n = images.len() as u16;
-                let elem_h = (elem_height(elem, None, img_h, None) as u16).min((height - y) as u16);
+                let elem_h =
+                    (elem_height(elem, None, img_h, None, None) as u16).min((height - y) as u16);
                 let indent_w = (*indent as u16) * 2;
                 let row_width = area.width.saturating_sub(indent_w);
                 let col_w = row_width / n;
@@ -616,8 +626,10 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
                 y += elem_h as usize;
             }
             DocElement::Math { content, indent } => {
-                let elem_h = (elem_height(elem, None, img_h, Some(&elem_heights)) as u16)
-                    .min((height - y) as u16);
+                let elem_h =
+                    (elem_height(elem, None, img_h, Some(&elem_heights), Some(&elem_widths))
+                        as u16)
+                        .min((height - y) as u16);
                 let indent_w = (*indent as u16) * 2;
                 let math_area = Rect::new(
                     area.x + indent_w,
@@ -656,48 +668,133 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
                 y += elem_h as usize;
             }
             DocElement::InlineMathLine { segments, .. } => {
-                // Height of this element (can be > 1 for tall expressions like fractions).
-                let elem_h = elem_h(elem) as u16;
-                // Text segments are vertically centred; math images anchor to top.
-                let text_row_y = area.y + y as u16 + elem_h / 2;
-                let math_row_y = area.y + y as u16;
-                let mut x_cursor = area.x;
+                // Total height of this element (accounts for wrap + math row heights).
+                let elem_total_h = elem_h(elem) as u16;
                 let max_x = area.x + area.width;
+                let col_width = area.width as usize;
+
+                // x_cursor and row_offset track position within the element.
+                // cur_row_h is the height of the current logical row.
+                let mut x_cursor: u16 = area.x;
+                let mut row_offset: u16 = 0;
+                let mut cur_row_h: u16 = 1;
+
                 for segment in segments {
-                    if x_cursor >= max_x {
-                        break;
-                    }
                     match segment {
                         InlineSegment::Text(spans) => {
-                            // Use Unicode display width (double-width CJK chars count as 2 cols).
-                            let text_width: u16 =
-                                spans.iter().map(|s| s.content.width() as u16).sum();
-                            let avail = max_x.saturating_sub(x_cursor);
-                            let w = text_width.min(avail);
-                            if w > 0 {
-                                let text_area = Rect::new(x_cursor, text_row_y, w, 1);
-                                frame.render_widget(
-                                    Paragraph::new(Line::from(spans.clone())),
-                                    text_area,
-                                );
+                            // Text is wrapped character-by-character so that text fills the
+                            // terminal edge before breaking, just like regular text lines.
+                            let mut row_x_start = x_cursor;
+                            let mut sub_spans: Vec<Span<'static>> = Vec::new();
+                            let mut cur_buf = String::new();
+                            let mut cur_style: Style =
+                                spans.first().map(|s| s.style).unwrap_or_default();
+
+                            for span in spans {
+                                if span.style != cur_style {
+                                    if !cur_buf.is_empty() {
+                                        sub_spans.push(Span::styled(
+                                            std::mem::take(&mut cur_buf),
+                                            cur_style,
+                                        ));
+                                    }
+                                    cur_style = span.style;
+                                }
+                                for ch in span.content.chars() {
+                                    let ch_w = UnicodeWidthChar::width(ch).unwrap_or(0) as u16;
+                                    if wrap
+                                        && col_width > 0
+                                        && (x_cursor as usize + ch_w as usize)
+                                            > (area.x as usize + col_width)
+                                    {
+                                        // Flush accumulated text to current row.
+                                        if !cur_buf.is_empty() {
+                                            sub_spans.push(Span::styled(
+                                                std::mem::take(&mut cur_buf),
+                                                cur_style,
+                                            ));
+                                        }
+                                        if !sub_spans.is_empty() {
+                                            let text_y =
+                                                area.y + y as u16 + row_offset + cur_row_h / 2;
+                                            let sub_w = x_cursor.saturating_sub(row_x_start);
+                                            let avail_rows = (height as u16)
+                                                .saturating_sub(y as u16 + row_offset);
+                                            if sub_w > 0 && avail_rows > 0 {
+                                                frame.render_widget(
+                                                    Paragraph::new(Line::from(std::mem::take(
+                                                        &mut sub_spans,
+                                                    ))),
+                                                    Rect::new(row_x_start, text_y, sub_w, 1),
+                                                );
+                                            } else {
+                                                sub_spans.clear();
+                                            }
+                                        }
+                                        // Start new row.
+                                        row_offset += cur_row_h;
+                                        x_cursor = area.x;
+                                        cur_row_h = 1;
+                                        row_x_start = area.x;
+                                    }
+                                    if ch_w > 0 {
+                                        cur_buf.push(ch);
+                                        x_cursor = x_cursor.saturating_add(ch_w).min(max_x);
+                                    }
+                                }
                             }
-                            x_cursor = x_cursor.saturating_add(text_width).min(max_x);
+                            // Flush remaining chars.
+                            if !cur_buf.is_empty() {
+                                sub_spans.push(Span::styled(cur_buf, cur_style));
+                            }
+                            if !sub_spans.is_empty() {
+                                let text_y = area.y + y as u16 + row_offset + cur_row_h / 2;
+                                let sub_w = x_cursor.saturating_sub(row_x_start);
+                                let avail_rows =
+                                    (height as u16).saturating_sub(y as u16 + row_offset);
+                                if sub_w > 0 && avail_rows > 0 {
+                                    frame.render_widget(
+                                        Paragraph::new(Line::from(sub_spans)),
+                                        Rect::new(row_x_start, text_y, sub_w, 1),
+                                    );
+                                }
+                            }
+                            // Text doesn't increase cur_row_h beyond 1.
+                            cur_row_h = cur_row_h.max(1);
                         }
                         InlineSegment::Math(content) => {
+                            let seg_w = app.images.inline_math_cols(content).unwrap_or(4);
                             let key = crate::image_cache::ImageCache::inline_math_key(content);
-                            let cols = app.images.inline_math_cols(content).unwrap_or(4);
-                            let math_rows = app
+                            let seg_h = app
                                 .images
                                 .elem_heights
                                 .get(key.as_str())
                                 .copied()
                                 .unwrap_or(1);
-                            let avail = max_x.saturating_sub(x_cursor);
-                            let w = cols.min(avail);
-                            let avail_rows = (height - y) as u16;
-                            let h = math_rows.min(avail_rows).max(1);
-                            if w > 0 {
-                                let math_area = Rect::new(x_cursor, math_row_y, w, h);
+
+                            // Math segments are atomic: wrap the whole image if it
+                            // doesn't fit on the current row.
+                            if wrap
+                                && col_width > 0
+                                && x_cursor > area.x
+                                && (x_cursor as usize + seg_w as usize)
+                                    > (area.x as usize + col_width)
+                            {
+                                row_offset += cur_row_h;
+                                x_cursor = area.x;
+                                cur_row_h = seg_h;
+                            } else {
+                                cur_row_h = cur_row_h.max(seg_h);
+                            }
+
+                            let avail_x = max_x.saturating_sub(x_cursor);
+                            let w = (seg_w as u16).min(avail_x);
+                            let avail_rows = (height as u16).saturating_sub(y as u16 + row_offset);
+                            let h = seg_h.min(avail_rows).max(1);
+                            let base_y = area.y + y as u16 + row_offset;
+
+                            if w > 0 && avail_rows > 0 {
+                                let math_area = Rect::new(x_cursor, base_y, w, h);
                                 match app.images.get_mut(&key) {
                                     Some(_) => {
                                         draw_image_cell(
@@ -710,22 +807,21 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
                                         );
                                     }
                                     None => {
-                                        // Fallback: show raw LaTeX in magenta
                                         frame.render_widget(
                                             Paragraph::new(Line::from(vec![Span::styled(
                                                 content.as_str().to_string(),
                                                 Style::default().fg(Color::Magenta),
                                             )])),
-                                            Rect::new(x_cursor, text_row_y, w, 1),
+                                            Rect::new(x_cursor, base_y, w, 1),
                                         );
                                     }
                                 }
                             }
-                            x_cursor = x_cursor.saturating_add(cols).min(max_x);
+                            x_cursor = x_cursor.saturating_add(seg_w as u16).min(max_x);
                         }
                     }
                 }
-                y += elem_h as usize;
+                y += elem_total_h as usize;
             }
         }
     }

--- a/src/bin/patto-preview-tui/ui.rs
+++ b/src/bin/patto-preview-tui/ui.rs
@@ -13,7 +13,7 @@ use ratatui::{
 use ratatui_image::StatefulImage;
 use std::path::Path;
 use tui_widget_list::{ListBuilder, ListView};
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::UnicodeWidthChar;
 
 use crate::app::App;
 use crate::image_cache::CachedImage;
@@ -65,8 +65,7 @@ fn draw_title_bar(frame: &mut Frame, area: Rect, app: &App) {
         &app.rendered_doc.elements,
         app.wrap_config().as_ref(),
         app.images.height_rows,
-        Some(&app.images.elem_heights),
-        Some(&app.images.elem_widths),
+        Some(&app.images.elem_sizes),
     );
     let (pos, pct) = if total > 0 {
         let p = ((app.scroll_offset + 1) * 100 / total).min(100);
@@ -330,15 +329,165 @@ fn draw_image_cell(
     }
 }
 
+/// Render an `InlineMathLine` — text segments wrap character-by-character while
+/// math images are treated as atomic units.
+fn draw_inline_math_line(
+    frame: &mut Frame,
+    segments: &[InlineSegment],
+    area: Rect,
+    y: usize,
+    height: usize,
+    wrap: bool,
+    images: &mut crate::image_cache::ImageCache,
+) {
+    let max_x = area.x + area.width;
+    let col_width = area.width as usize;
+
+    let mut x_cursor: u16 = area.x;
+    let mut row_offset: u16 = 0;
+    let mut cur_row_h: u16 = 1;
+
+    for segment in segments {
+        match segment {
+            InlineSegment::Text(spans) => {
+                let mut row_x_start = x_cursor;
+                let mut sub_spans: Vec<Span<'static>> = Vec::new();
+                let mut cur_buf = String::new();
+                let mut cur_style: Style =
+                    spans.first().map(|s| s.style).unwrap_or_default();
+
+                for span in spans {
+                    if span.style != cur_style {
+                        if !cur_buf.is_empty() {
+                            sub_spans.push(Span::styled(
+                                std::mem::take(&mut cur_buf),
+                                cur_style,
+                            ));
+                        }
+                        cur_style = span.style;
+                    }
+                    for ch in span.content.chars() {
+                        let ch_w = UnicodeWidthChar::width(ch).unwrap_or(0) as u16;
+                        if wrap
+                            && col_width > 0
+                            && (x_cursor as usize + ch_w as usize)
+                                > (area.x as usize + col_width)
+                        {
+                            // Flush accumulated text to the current row.
+                            if !cur_buf.is_empty() {
+                                sub_spans.push(Span::styled(
+                                    std::mem::take(&mut cur_buf),
+                                    cur_style,
+                                ));
+                            }
+                            if !sub_spans.is_empty() {
+                                let text_y =
+                                    area.y + y as u16 + row_offset + cur_row_h / 2;
+                                let sub_w = x_cursor.saturating_sub(row_x_start);
+                                let avail_rows = (height as u16)
+                                    .saturating_sub(y as u16 + row_offset);
+                                if sub_w > 0 && avail_rows > 0 {
+                                    frame.render_widget(
+                                        Paragraph::new(Line::from(std::mem::take(
+                                            &mut sub_spans,
+                                        ))),
+                                        Rect::new(row_x_start, text_y, sub_w, 1),
+                                    );
+                                } else {
+                                    sub_spans.clear();
+                                }
+                            }
+                            row_offset += cur_row_h;
+                            x_cursor = area.x;
+                            cur_row_h = 1;
+                            row_x_start = area.x;
+                        }
+                        if ch_w > 0 {
+                            cur_buf.push(ch);
+                            x_cursor = x_cursor.saturating_add(ch_w).min(max_x);
+                        }
+                    }
+                }
+                if !cur_buf.is_empty() {
+                    sub_spans.push(Span::styled(cur_buf, cur_style));
+                }
+                if !sub_spans.is_empty() {
+                    let text_y = area.y + y as u16 + row_offset + cur_row_h / 2;
+                    let sub_w = x_cursor.saturating_sub(row_x_start);
+                    let avail_rows =
+                        (height as u16).saturating_sub(y as u16 + row_offset);
+                    if sub_w > 0 && avail_rows > 0 {
+                        frame.render_widget(
+                            Paragraph::new(Line::from(sub_spans)),
+                            Rect::new(row_x_start, text_y, sub_w, 1),
+                        );
+                    }
+                }
+                cur_row_h = cur_row_h.max(1);
+            }
+            InlineSegment::Math(content) => {
+                let seg_w = images.inline_math_cols(content).unwrap_or(4);
+                let key = crate::image_cache::ImageCache::inline_math_key(content);
+                let seg_h = images
+                    .elem_sizes
+                    .heights
+                    .get(key.as_str())
+                    .copied()
+                    .unwrap_or(1);
+
+                if wrap
+                    && col_width > 0
+                    && x_cursor > area.x
+                    && (x_cursor as usize + seg_w as usize)
+                        > (area.x as usize + col_width)
+                {
+                    row_offset += cur_row_h;
+                    x_cursor = area.x;
+                    cur_row_h = seg_h;
+                } else {
+                    cur_row_h = cur_row_h.max(seg_h);
+                }
+
+                let avail_x = max_x.saturating_sub(x_cursor);
+                let w = (seg_w as u16).min(avail_x);
+                let avail_rows =
+                    (height as u16).saturating_sub(y as u16 + row_offset);
+                let h = seg_h.min(avail_rows).max(1);
+                let base_y = area.y + y as u16 + row_offset;
+
+                if w > 0 && avail_rows > 0 {
+                    let math_area = Rect::new(x_cursor, base_y, w, h);
+                    match images.get_mut(&key) {
+                        Some(_) => {
+                            draw_image_cell(
+                                frame, images, &key, None, math_area, false,
+                            );
+                        }
+                        None => {
+                            frame.render_widget(
+                                Paragraph::new(Line::from(vec![Span::styled(
+                                    content.as_str().to_string(),
+                                    Style::default().fg(Color::Magenta),
+                                )])),
+                                Rect::new(x_cursor, base_y, w, 1),
+                            );
+                        }
+                    }
+                }
+                x_cursor = x_cursor.saturating_add(seg_w as u16).min(max_x);
+            }
+        }
+    }
+}
+
 fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
     let height = area.height as usize;
     let img_h = app.images.height_rows;
     let wrap = app.wrap;
     let showbreak = app.showbreak.clone();
-    // Snapshot elem_heights/elem_widths so the closure doesn't hold a borrow on
+    // Snapshot element sizes so the closure doesn't hold a borrow on
     // app.images while we later call app.images.load() / load_math() mutably.
-    let elem_heights = app.images.elem_heights.clone();
-    let elem_widths = app.images.elem_widths.clone();
+    let elem_sizes = app.images.elem_sizes.clone();
     // Update viewport dimensions (used by wrap-aware scroll calculations)
     app.viewport_width = area.width;
     app.viewport_height = height;
@@ -353,13 +502,7 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
         } else {
             None
         };
-        elem_height(
-            elem,
-            cfg_opt,
-            img_h,
-            Some(&elem_heights),
-            Some(&elem_widths),
-        )
+        elem_height(elem, cfg_opt, img_h, Some(&elem_sizes))
     };
 
     // Skip elements until we reach scroll_offset rows
@@ -376,92 +519,34 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
         }
     }
 
-    // Pre-load images that will be visible (only scan viewport-worth of elements)
-    let mut scan_rows = 0usize;
-    let image_srcs: Vec<String> = app
-        .rendered_doc
-        .elements
-        .iter()
-        .skip(start_elem)
-        .take_while(|elem| {
-            let h = elem_h(elem);
-            scan_rows += h;
-            scan_rows <= height + img_h as usize
-        })
-        .filter_map(|elem| match elem {
-            DocElement::Image { src, .. } => Some(vec![src.clone()]),
+    // Pre-load images, math blocks, and inline math in the viewport (single pass).
+    let inline_math = app.inline_math_rendering;
+    let mut preload_rows = 0usize;
+    for elem in app.rendered_doc.elements.iter().skip(start_elem) {
+        preload_rows += elem_h(elem);
+        if preload_rows > height + img_h as usize {
+            break;
+        }
+        match elem {
+            DocElement::Image { src, .. } => {
+                app.images.load(src, root_dir);
+            }
             DocElement::ImageRow(images, ..) => {
-                Some(images.iter().map(|(s, _)| s.clone()).collect())
-            }
-            _ => None,
-        })
-        .flatten()
-        .collect();
-    for src in &image_srcs {
-        app.images.load(src, root_dir);
-    }
-
-    // Pre-load math blocks in the viewport
-    let math_contents: Vec<String> = app
-        .rendered_doc
-        .elements
-        .iter()
-        .skip(start_elem)
-        .take_while({
-            let mut rows = 0usize;
-            move |elem| {
-                rows += elem_h(elem);
-                rows <= height + img_h as usize
-            }
-        })
-        .filter_map(|elem| {
-            if let DocElement::Math { content, .. } = elem {
-                Some(content.clone())
-            } else {
-                None
-            }
-        })
-        .collect();
-    for content in &math_contents {
-        app.images.load_math(content);
-    }
-
-    // Pre-load inline math segments in the viewport
-    if app.inline_math_rendering {
-        let inline_math_contents: Vec<String> = app
-            .rendered_doc
-            .elements
-            .iter()
-            .skip(start_elem)
-            .take_while({
-                let mut rows = 0usize;
-                move |elem| {
-                    rows += elem_h(elem);
-                    rows <= height + img_h as usize
+                for (s, _) in images {
+                    app.images.load(s, root_dir);
                 }
-            })
-            .filter_map(|elem| {
-                if let DocElement::InlineMathLine { segments, .. } = elem {
-                    Some(
-                        segments
-                            .iter()
-                            .filter_map(|s| {
-                                if let InlineSegment::Math(c) = s {
-                                    Some(c.clone())
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect::<Vec<_>>(),
-                    )
-                } else {
-                    None
+            }
+            DocElement::Math { content, .. } => {
+                app.images.load_math(content);
+            }
+            DocElement::InlineMathLine { segments, .. } if inline_math => {
+                for seg in segments {
+                    if let InlineSegment::Math(c) = seg {
+                        app.images.load_inline_math(c);
+                    }
                 }
-            })
-            .flatten()
-            .collect();
-        for content in &inline_math_contents {
-            app.images.load_inline_math(content);
+            }
+            _ => {}
         }
     }
 
@@ -569,7 +654,7 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
             }
             DocElement::Image { src, alt, indent } => {
                 let elem_h =
-                    (elem_height(elem, None, img_h, None, None) as u16).min((height - y) as u16);
+                    (elem_height(elem, None, img_h, None) as u16).min((height - y) as u16);
                 let indent_w = (*indent as u16) * 2;
                 let img_area = Rect::new(
                     area.x + indent_w,
@@ -590,7 +675,7 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
             DocElement::ImageRow(images, indent) => {
                 let n = images.len() as u16;
                 let elem_h =
-                    (elem_height(elem, None, img_h, None, None) as u16).min((height - y) as u16);
+                    (elem_height(elem, None, img_h, None) as u16).min((height - y) as u16);
                 let indent_w = (*indent as u16) * 2;
                 let row_width = area.width.saturating_sub(indent_w);
                 let col_w = row_width / n;
@@ -627,7 +712,7 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
             }
             DocElement::Math { content, indent } => {
                 let elem_h =
-                    (elem_height(elem, None, img_h, Some(&elem_heights), Some(&elem_widths))
+                    (elem_height(elem, None, img_h, Some(&elem_sizes))
                         as u16)
                         .min((height - y) as u16);
                 let indent_w = (*indent as u16) * 2;
@@ -668,159 +753,11 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
                 y += elem_h as usize;
             }
             DocElement::InlineMathLine { segments, .. } => {
-                // Total height of this element (accounts for wrap + math row heights).
                 let elem_total_h = elem_h(elem) as u16;
-                let max_x = area.x + area.width;
-                let col_width = area.width as usize;
-
-                // x_cursor and row_offset track position within the element.
-                // cur_row_h is the height of the current logical row.
-                let mut x_cursor: u16 = area.x;
-                let mut row_offset: u16 = 0;
-                let mut cur_row_h: u16 = 1;
-
-                for segment in segments {
-                    match segment {
-                        InlineSegment::Text(spans) => {
-                            // Text is wrapped character-by-character so that text fills the
-                            // terminal edge before breaking, just like regular text lines.
-                            let mut row_x_start = x_cursor;
-                            let mut sub_spans: Vec<Span<'static>> = Vec::new();
-                            let mut cur_buf = String::new();
-                            let mut cur_style: Style =
-                                spans.first().map(|s| s.style).unwrap_or_default();
-
-                            for span in spans {
-                                if span.style != cur_style {
-                                    if !cur_buf.is_empty() {
-                                        sub_spans.push(Span::styled(
-                                            std::mem::take(&mut cur_buf),
-                                            cur_style,
-                                        ));
-                                    }
-                                    cur_style = span.style;
-                                }
-                                for ch in span.content.chars() {
-                                    let ch_w = UnicodeWidthChar::width(ch).unwrap_or(0) as u16;
-                                    if wrap
-                                        && col_width > 0
-                                        && (x_cursor as usize + ch_w as usize)
-                                            > (area.x as usize + col_width)
-                                    {
-                                        // Flush accumulated text to current row.
-                                        if !cur_buf.is_empty() {
-                                            sub_spans.push(Span::styled(
-                                                std::mem::take(&mut cur_buf),
-                                                cur_style,
-                                            ));
-                                        }
-                                        if !sub_spans.is_empty() {
-                                            let text_y =
-                                                area.y + y as u16 + row_offset + cur_row_h / 2;
-                                            let sub_w = x_cursor.saturating_sub(row_x_start);
-                                            let avail_rows = (height as u16)
-                                                .saturating_sub(y as u16 + row_offset);
-                                            if sub_w > 0 && avail_rows > 0 {
-                                                frame.render_widget(
-                                                    Paragraph::new(Line::from(std::mem::take(
-                                                        &mut sub_spans,
-                                                    ))),
-                                                    Rect::new(row_x_start, text_y, sub_w, 1),
-                                                );
-                                            } else {
-                                                sub_spans.clear();
-                                            }
-                                        }
-                                        // Start new row.
-                                        row_offset += cur_row_h;
-                                        x_cursor = area.x;
-                                        cur_row_h = 1;
-                                        row_x_start = area.x;
-                                    }
-                                    if ch_w > 0 {
-                                        cur_buf.push(ch);
-                                        x_cursor = x_cursor.saturating_add(ch_w).min(max_x);
-                                    }
-                                }
-                            }
-                            // Flush remaining chars.
-                            if !cur_buf.is_empty() {
-                                sub_spans.push(Span::styled(cur_buf, cur_style));
-                            }
-                            if !sub_spans.is_empty() {
-                                let text_y = area.y + y as u16 + row_offset + cur_row_h / 2;
-                                let sub_w = x_cursor.saturating_sub(row_x_start);
-                                let avail_rows =
-                                    (height as u16).saturating_sub(y as u16 + row_offset);
-                                if sub_w > 0 && avail_rows > 0 {
-                                    frame.render_widget(
-                                        Paragraph::new(Line::from(sub_spans)),
-                                        Rect::new(row_x_start, text_y, sub_w, 1),
-                                    );
-                                }
-                            }
-                            // Text doesn't increase cur_row_h beyond 1.
-                            cur_row_h = cur_row_h.max(1);
-                        }
-                        InlineSegment::Math(content) => {
-                            let seg_w = app.images.inline_math_cols(content).unwrap_or(4);
-                            let key = crate::image_cache::ImageCache::inline_math_key(content);
-                            let seg_h = app
-                                .images
-                                .elem_heights
-                                .get(key.as_str())
-                                .copied()
-                                .unwrap_or(1);
-
-                            // Math segments are atomic: wrap the whole image if it
-                            // doesn't fit on the current row.
-                            if wrap
-                                && col_width > 0
-                                && x_cursor > area.x
-                                && (x_cursor as usize + seg_w as usize)
-                                    > (area.x as usize + col_width)
-                            {
-                                row_offset += cur_row_h;
-                                x_cursor = area.x;
-                                cur_row_h = seg_h;
-                            } else {
-                                cur_row_h = cur_row_h.max(seg_h);
-                            }
-
-                            let avail_x = max_x.saturating_sub(x_cursor);
-                            let w = (seg_w as u16).min(avail_x);
-                            let avail_rows = (height as u16).saturating_sub(y as u16 + row_offset);
-                            let h = seg_h.min(avail_rows).max(1);
-                            let base_y = area.y + y as u16 + row_offset;
-
-                            if w > 0 && avail_rows > 0 {
-                                let math_area = Rect::new(x_cursor, base_y, w, h);
-                                match app.images.get_mut(&key) {
-                                    Some(_) => {
-                                        draw_image_cell(
-                                            frame,
-                                            &mut app.images,
-                                            &key,
-                                            None,
-                                            math_area,
-                                            false,
-                                        );
-                                    }
-                                    None => {
-                                        frame.render_widget(
-                                            Paragraph::new(Line::from(vec![Span::styled(
-                                                content.as_str().to_string(),
-                                                Style::default().fg(Color::Magenta),
-                                            )])),
-                                            Rect::new(x_cursor, base_y, w, 1),
-                                        );
-                                    }
-                                }
-                            }
-                            x_cursor = x_cursor.saturating_add(seg_w as u16).min(max_x);
-                        }
-                    }
-                }
+                draw_inline_math_line(
+                    frame, segments, area, y, height, wrap,
+                    &mut app.images,
+                );
                 y += elem_total_h as usize;
             }
         }

--- a/src/bin/patto-preview-tui/ui.rs
+++ b/src/bin/patto-preview-tui/ui.rs
@@ -1144,7 +1144,6 @@ fn draw_active_task_overlay(frame: &mut Frame, content_area: Rect, app: &App) {
     // Show at most 3 tasks.
     let max_rows = 3usize;
     let tasks_to_show: Vec<_> = active.iter().take(max_rows).collect();
-    let num_rows = tasks_to_show.len() as u16;
 
     // Max width cap: 60% of content width, min 20 cols.
     let max_w = (content_area.width * 60 / 100)

--- a/src/bin/patto-preview-tui/ui.rs
+++ b/src/bin/patto-preview-tui/ui.rs
@@ -1,7 +1,7 @@
 use crate::backlinks::FlatEntry;
 use crate::config::TasksPanelPosition;
 use crate::tasks::TaskEntry;
-use patto::tui_renderer::{DocElement, LinkAction};
+use patto::tui_renderer::{DocElement, InlineSegment, LinkAction};
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Direction, Layout, Rect},
@@ -13,6 +13,7 @@ use ratatui::{
 use ratatui_image::StatefulImage;
 use std::path::Path;
 use tui_widget_list::{ListBuilder, ListView};
+use unicode_width::UnicodeWidthStr;
 
 use crate::app::App;
 use crate::image_cache::CachedImage;
@@ -417,6 +418,45 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
         app.images.load_math(content);
     }
 
+    // Pre-load inline math segments in the viewport
+    if app.inline_math_rendering {
+        let inline_math_contents: Vec<String> = app
+            .rendered_doc
+            .elements
+            .iter()
+            .skip(start_elem)
+            .take_while({
+                let mut rows = 0usize;
+                move |elem| {
+                    rows += elem_h(elem);
+                    rows <= height + img_h as usize
+                }
+            })
+            .filter_map(|elem| {
+                if let DocElement::InlineMathLine { segments, .. } = elem {
+                    Some(
+                        segments
+                            .iter()
+                            .filter_map(|s| {
+                                if let InlineSegment::Math(c) = s {
+                                    Some(c.clone())
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                } else {
+                    None
+                }
+            })
+            .flatten()
+            .collect();
+        for content in &inline_math_contents {
+            app.images.load_inline_math(content);
+        }
+    }
+
     // Render visible elements
     // Determine which element index is focused and get char range for text highlights
     let (focused_elem_idx, focused_char_range) = match app.focused_item() {
@@ -611,6 +651,78 @@ fn draw_content(frame: &mut Frame, area: Rect, app: &mut App, root_dir: &Path) {
                         .take(elem_h as usize)
                         .collect();
                         frame.render_widget(Paragraph::new(lines), math_area);
+                    }
+                }
+                y += elem_h as usize;
+            }
+            DocElement::InlineMathLine { segments, .. } => {
+                // Height of this element (can be > 1 for tall expressions like fractions).
+                let elem_h = elem_h(elem) as u16;
+                // Text segments are vertically centred; math images anchor to top.
+                let text_row_y = area.y + y as u16 + elem_h / 2;
+                let math_row_y = area.y + y as u16;
+                let mut x_cursor = area.x;
+                let max_x = area.x + area.width;
+                for segment in segments {
+                    if x_cursor >= max_x {
+                        break;
+                    }
+                    match segment {
+                        InlineSegment::Text(spans) => {
+                            // Use Unicode display width (double-width CJK chars count as 2 cols).
+                            let text_width: u16 =
+                                spans.iter().map(|s| s.content.width() as u16).sum();
+                            let avail = max_x.saturating_sub(x_cursor);
+                            let w = text_width.min(avail);
+                            if w > 0 {
+                                let text_area = Rect::new(x_cursor, text_row_y, w, 1);
+                                frame.render_widget(
+                                    Paragraph::new(Line::from(spans.clone())),
+                                    text_area,
+                                );
+                            }
+                            x_cursor = x_cursor.saturating_add(text_width).min(max_x);
+                        }
+                        InlineSegment::Math(content) => {
+                            let key = crate::image_cache::ImageCache::inline_math_key(content);
+                            let cols = app.images.inline_math_cols(content).unwrap_or(4);
+                            let math_rows = app
+                                .images
+                                .elem_heights
+                                .get(key.as_str())
+                                .copied()
+                                .unwrap_or(1);
+                            let avail = max_x.saturating_sub(x_cursor);
+                            let w = cols.min(avail);
+                            let avail_rows = (height - y) as u16;
+                            let h = math_rows.min(avail_rows).max(1);
+                            if w > 0 {
+                                let math_area = Rect::new(x_cursor, math_row_y, w, h);
+                                match app.images.get_mut(&key) {
+                                    Some(_) => {
+                                        draw_image_cell(
+                                            frame,
+                                            &mut app.images,
+                                            &key,
+                                            None,
+                                            math_area,
+                                            false,
+                                        );
+                                    }
+                                    None => {
+                                        // Fallback: show raw LaTeX in magenta
+                                        frame.render_widget(
+                                            Paragraph::new(Line::from(vec![Span::styled(
+                                                content.as_str().to_string(),
+                                                Style::default().fg(Color::Magenta),
+                                            )])),
+                                            Rect::new(x_cursor, text_row_y, w, 1),
+                                        );
+                                    }
+                                }
+                            }
+                            x_cursor = x_cursor.saturating_add(cols).min(max_x);
+                        }
                     }
                 }
                 y += elem_h as usize;

--- a/src/bin/patto-preview-tui/wrap.rs
+++ b/src/bin/patto-preview-tui/wrap.rs
@@ -14,6 +14,25 @@ use ratatui::{
 use std::collections::HashMap;
 use unicode_width::UnicodeWidthChar;
 
+/// Cached element sizes (heights and widths) used by scroll math and rendering.
+///
+/// Images and math blocks store their height (in terminal rows); inline math
+/// images additionally store their width (in terminal columns).
+#[derive(Clone, Default)]
+pub struct ElemSizeCache {
+    /// Cache key → height in terminal rows.
+    pub heights: HashMap<String, u16>,
+    /// Cache key → width in terminal columns (inline math only).
+    pub widths: HashMap<String, u16>,
+}
+
+impl ElemSizeCache {
+    pub fn clear(&mut self) {
+        self.heights.clear();
+        self.widths.clear();
+    }
+}
+
 /// Parameters that control how lines are soft-wrapped.
 #[derive(Clone)]
 pub struct WrapConfig {
@@ -99,19 +118,15 @@ pub fn count_wrap_rows(line: &Line<'_>, cfg: &WrapConfig) -> usize {
 /// Height of a single `DocElement` in terminal rows.
 ///
 /// - Pass a `WrapConfig` to get soft-wrap–aware height for `TextLine` elements.
-/// - Pass `None` (or a zero-width config) to get the unwarpped height (always 1
+/// - Pass `None` (or a zero-width config) to get the unwrapped height (always 1
 ///   for `TextLine` / `Spacer`).
 /// - `img_h` is the configured default height in terminal rows (fallback).
-/// - `elem_heights` maps cache key → actual row height for each loaded element;
-///   both images (stored at `height_rows`) and math (pixel-computed) live here.
-/// - `elem_widths` maps inline-math cache key → column width; used for wrap
-///   height calculation of `InlineMathLine` elements.
+/// - `sizes` provides cached heights and widths for images and math elements.
 pub fn elem_height(
     elem: &DocElement,
     cfg: Option<&WrapConfig>,
     img_h: u16,
-    elem_heights: Option<&HashMap<String, u16>>,
-    elem_widths: Option<&HashMap<String, u16>>,
+    sizes: Option<&ElemSizeCache>,
 ) -> usize {
     if let Some(cfg) = cfg {
         if cfg.col_width > 0 {
@@ -119,21 +134,17 @@ pub fn elem_height(
                 return count_wrap_rows(line, cfg);
             }
             if let DocElement::InlineMathLine { segments, .. } = elem {
-                return inline_math_line_wrap_height(
-                    segments,
-                    cfg.col_width,
-                    elem_heights,
-                    elem_widths,
-                );
+                return inline_math_line_wrap_height(segments, cfg.col_width, sizes);
             }
         }
     }
+    let heights = sizes.map(|s| &s.heights);
     match elem {
         DocElement::TextLine(_, _) | DocElement::Spacer => 1,
-        DocElement::Image { src, .. } => elem_heights
+        DocElement::Image { src, .. } => heights
             .and_then(|m| m.get(src.as_str()).copied())
             .unwrap_or(img_h) as usize,
-        DocElement::ImageRow(images, ..) => elem_heights
+        DocElement::ImageRow(images, ..) => heights
             .map(|m| {
                 images
                     .iter()
@@ -142,12 +153,11 @@ pub fn elem_height(
                     .unwrap_or(img_h)
             })
             .unwrap_or(img_h) as usize,
-        DocElement::Math { content, .. } => elem_heights
+        DocElement::Math { content, .. } => heights
             .and_then(|m| m.get(content.as_str()).copied())
             .unwrap_or(img_h) as usize,
         DocElement::InlineMathLine { segments, .. } => {
-            // No wrap config: height = tallest inline math image in the line (min 1).
-            inline_math_line_wrap_height(segments, 0, elem_heights, elem_widths)
+            inline_math_line_wrap_height(segments, 0, sizes)
         }
     }
 }
@@ -161,19 +171,18 @@ pub fn elem_height(
 fn inline_math_line_wrap_height(
     segments: &[InlineSegment],
     col_width: usize,
-    elem_heights: Option<&HashMap<String, u16>>,
-    elem_widths: Option<&HashMap<String, u16>>,
+    sizes: Option<&ElemSizeCache>,
 ) -> usize {
     let math_seg_h = |content: &str| -> usize {
         let key = format!("__inline__:{}", content);
-        elem_heights
-            .and_then(|m| m.get(key.as_str()).copied())
+        sizes
+            .and_then(|s| s.heights.get(key.as_str()).copied())
             .unwrap_or(1) as usize
     };
     let math_seg_w = |content: &str| -> usize {
         let key = format!("__inline__:{}", content);
-        elem_widths
-            .and_then(|m| m.get(key.as_str()).copied())
+        sizes
+            .and_then(|s| s.widths.get(key.as_str()).copied())
             .unwrap_or(4) as usize
     };
 
@@ -228,12 +237,11 @@ pub fn total_height(
     elements: &[DocElement],
     cfg: Option<&WrapConfig>,
     img_h: u16,
-    elem_heights: Option<&HashMap<String, u16>>,
-    elem_widths: Option<&HashMap<String, u16>>,
+    sizes: Option<&ElemSizeCache>,
 ) -> usize {
     elements
         .iter()
-        .map(|e| elem_height(e, cfg, img_h, elem_heights, elem_widths))
+        .map(|e| elem_height(e, cfg, img_h, sizes))
         .sum()
 }
 

--- a/src/bin/patto-preview-tui/wrap.rs
+++ b/src/bin/patto-preview-tui/wrap.rs
@@ -6,7 +6,7 @@
 //! `total_height` — which replaces `DocElement::height` / `RenderedDoc::total_height`
 //! so that the data model stays free of rendering parameters.
 
-use patto::tui_renderer::DocElement;
+use patto::tui_renderer::{DocElement, InlineSegment};
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -134,6 +134,25 @@ pub fn elem_height(
         DocElement::Math { content, .. } => elem_heights
             .and_then(|m| m.get(content.as_str()).copied())
             .unwrap_or(img_h) as usize,
+        DocElement::InlineMathLine { segments, .. } => {
+            // Height = tallest inline math image in this line (min 1).
+            elem_heights
+                .map(|m| {
+                    segments
+                        .iter()
+                        .filter_map(|s| {
+                            if let InlineSegment::Math(content) = s {
+                                let key = format!("__inline__:{}", content);
+                                m.get(key.as_str()).copied()
+                            } else {
+                                None
+                            }
+                        })
+                        .max()
+                        .unwrap_or(1)
+                })
+                .unwrap_or(1) as usize
+        }
     }
 }
 

--- a/src/bin/patto-preview-tui/wrap.rs
+++ b/src/bin/patto-preview-tui/wrap.rs
@@ -104,16 +104,27 @@ pub fn count_wrap_rows(line: &Line<'_>, cfg: &WrapConfig) -> usize {
 /// - `img_h` is the configured default height in terminal rows (fallback).
 /// - `elem_heights` maps cache key → actual row height for each loaded element;
 ///   both images (stored at `height_rows`) and math (pixel-computed) live here.
+/// - `elem_widths` maps inline-math cache key → column width; used for wrap
+///   height calculation of `InlineMathLine` elements.
 pub fn elem_height(
     elem: &DocElement,
     cfg: Option<&WrapConfig>,
     img_h: u16,
     elem_heights: Option<&HashMap<String, u16>>,
+    elem_widths: Option<&HashMap<String, u16>>,
 ) -> usize {
     if let Some(cfg) = cfg {
         if cfg.col_width > 0 {
             if let DocElement::TextLine(line, _) = elem {
                 return count_wrap_rows(line, cfg);
+            }
+            if let DocElement::InlineMathLine { segments, .. } = elem {
+                return inline_math_line_wrap_height(
+                    segments,
+                    cfg.col_width,
+                    elem_heights,
+                    elem_widths,
+                );
             }
         }
     }
@@ -135,25 +146,81 @@ pub fn elem_height(
             .and_then(|m| m.get(content.as_str()).copied())
             .unwrap_or(img_h) as usize,
         DocElement::InlineMathLine { segments, .. } => {
-            // Height = tallest inline math image in this line (min 1).
-            elem_heights
-                .map(|m| {
-                    segments
-                        .iter()
-                        .filter_map(|s| {
-                            if let InlineSegment::Math(content) = s {
-                                let key = format!("__inline__:{}", content);
-                                m.get(key.as_str()).copied()
-                            } else {
-                                None
-                            }
-                        })
-                        .max()
-                        .unwrap_or(1)
-                })
-                .unwrap_or(1) as usize
+            // No wrap config: height = tallest inline math image in the line (min 1).
+            inline_math_line_wrap_height(segments, 0, elem_heights, elem_widths)
         }
     }
+}
+
+/// Compute the display height of an `InlineMathLine` given a maximum column width.
+///
+/// Text segments are wrapped character-by-character (mirroring the ui.rs render arm).
+/// Math segments are treated atomically — if one doesn't fit, it moves to the next row.
+/// Each row's height equals the tallest math image on that row (minimum 1).
+/// When `col_width == 0` (no wrap) all segments share one row.
+fn inline_math_line_wrap_height(
+    segments: &[InlineSegment],
+    col_width: usize,
+    elem_heights: Option<&HashMap<String, u16>>,
+    elem_widths: Option<&HashMap<String, u16>>,
+) -> usize {
+    let math_seg_h = |content: &str| -> usize {
+        let key = format!("__inline__:{}", content);
+        elem_heights
+            .and_then(|m| m.get(key.as_str()).copied())
+            .unwrap_or(1) as usize
+    };
+    let math_seg_w = |content: &str| -> usize {
+        let key = format!("__inline__:{}", content);
+        elem_widths
+            .and_then(|m| m.get(key.as_str()).copied())
+            .unwrap_or(4) as usize
+    };
+
+    // Each entry is the height of that visual row.
+    let mut row_heights: Vec<usize> = vec![1];
+    let mut x = 0usize;
+
+    for seg in segments {
+        match seg {
+            InlineSegment::Text(spans) => {
+                // Text wraps character-by-character (mirrors ui.rs render arm).
+                for span in spans {
+                    for ch in span.content.chars() {
+                        let ch_w = UnicodeWidthChar::width(ch).unwrap_or(0);
+                        if ch_w == 0 {
+                            continue;
+                        }
+                        if col_width > 0 && (x + ch_w) > col_width {
+                            // Start a new text-only row (height 1).
+                            row_heights.push(1);
+                            x = ch_w;
+                        } else {
+                            x += ch_w;
+                        }
+                    }
+                }
+                // Text doesn't increase the current row's height.
+            }
+            InlineSegment::Math(c) => {
+                let (w, h) = (math_seg_w(c), math_seg_h(c));
+                if w == 0 {
+                    continue;
+                }
+                if col_width > 0 && x > 0 && x + w > col_width {
+                    // Math doesn't fit: start a new row.
+                    row_heights.push(h.max(1));
+                    x = w;
+                } else {
+                    // Math fits: update current row's height.
+                    let last = row_heights.last_mut().unwrap();
+                    *last = (*last).max(h);
+                    x += w;
+                }
+            }
+        }
+    }
+    row_heights.iter().sum()
 }
 
 /// Total height of a slice of elements in terminal rows.
@@ -162,10 +229,11 @@ pub fn total_height(
     cfg: Option<&WrapConfig>,
     img_h: u16,
     elem_heights: Option<&HashMap<String, u16>>,
+    elem_widths: Option<&HashMap<String, u16>>,
 ) -> usize {
     elements
         .iter()
-        .map(|e| elem_height(e, cfg, img_h, elem_heights))
+        .map(|e| elem_height(e, cfg, img_h, elem_heights, elem_widths))
         .sum()
 }
 

--- a/src/bin/patto-preview-tui/wrap.rs
+++ b/src/bin/patto-preview-tui/wrap.rs
@@ -14,6 +14,8 @@ use ratatui::{
 use std::collections::HashMap;
 use unicode_width::UnicodeWidthChar;
 
+use crate::image_cache::ImageCache;
+
 /// Cached element sizes (heights and widths) used by scroll math and rendering.
 ///
 /// Images and math blocks store their height (in terminal rows); inline math
@@ -174,13 +176,13 @@ fn inline_math_line_wrap_height(
     sizes: Option<&ElemSizeCache>,
 ) -> usize {
     let math_seg_h = |content: &str| -> usize {
-        let key = format!("__inline__:{}", content);
+        let key = ImageCache::inline_math_key(content);
         sizes
             .and_then(|s| s.heights.get(key.as_str()).copied())
             .unwrap_or(1) as usize
     };
     let math_seg_w = |content: &str| -> usize {
-        let key = format!("__inline__:{}", content);
+        let key = ImageCache::inline_math_key(content);
         sizes
             .and_then(|s| s.widths.get(key.as_str()).copied())
             .unwrap_or(4) as usize

--- a/src/tui_renderer.rs
+++ b/src/tui_renderer.rs
@@ -107,14 +107,7 @@ pub fn render_ast(ast: &AstNode, cfg: &RenderConfig<'_>) -> RenderedDoc {
     let mut elements = Vec::new();
     let mut focusables = Vec::new();
     let mut anchors = HashMap::new();
-    render_node(
-        ast,
-        &mut elements,
-        &mut focusables,
-        &mut anchors,
-        0,
-        cfg,
-    );
+    render_node(ast, &mut elements, &mut focusables, &mut anchors, 0, cfg);
     RenderedDoc {
         elements,
         focusables,
@@ -183,14 +176,7 @@ fn render_node(
         AstNodeKind::Dummy => {
             let children = ast.value().children.lock().unwrap();
             for child in children.iter() {
-                render_node(
-                    child,
-                    elements,
-                    focusables,
-                    anchors,
-                    indent,
-                    cfg,
-                );
+                render_node(child, elements, focusables, anchors, indent, cfg);
             }
         }
         AstNodeKind::Line { properties } | AstNodeKind::QuoteContent { properties } => {
@@ -211,25 +197,11 @@ fn render_node(
                 // Delegate to the block element renderer
                 let block_node = contents[0].clone();
                 drop(contents);
-                render_node(
-                    &block_node,
-                    elements,
-                    focusables,
-                    anchors,
-                    indent,
-                    cfg,
-                );
+                render_node(&block_node, elements, focusables, anchors, indent, cfg);
                 // Still render children (nested lines after the block)
                 let children = ast.value().children.lock().unwrap();
                 for child in children.iter() {
-                    render_node(
-                        child,
-                        elements,
-                        focusables,
-                        anchors,
-                        indent + 1,
-                        cfg,
-                    );
+                    render_node(child, elements, focusables, anchors, indent + 1, cfg);
                 }
                 return;
             }
@@ -383,27 +355,13 @@ fn render_node(
             // Children (nested lines)
             let children = ast.value().children.lock().unwrap();
             for child in children.iter() {
-                render_node(
-                    child,
-                    elements,
-                    focusables,
-                    anchors,
-                    indent + 1,
-                    cfg,
-                );
+                render_node(child, elements, focusables, anchors, indent + 1, cfg);
             }
         }
         AstNodeKind::Quote => {
             let children = ast.value().children.lock().unwrap();
             for child in children.iter() {
-                render_node(
-                    child,
-                    elements,
-                    focusables,
-                    anchors,
-                    indent,
-                    cfg,
-                );
+                render_node(child, elements, focusables, anchors, indent, cfg);
             }
         }
         AstNodeKind::Math { inline } => {
@@ -728,14 +686,8 @@ fn render_inline(
             }
             let contents = ast.value().contents.lock().unwrap();
             for content in contents.iter() {
-                let result = render_inline(
-                    content,
-                    spans,
-                    style,
-                    focusables,
-                    current_elem_idx,
-                    cfg,
-                );
+                let result =
+                    render_inline(content, spans, style, focusables, current_elem_idx, cfg);
                 if matches!(result, InlineResult::ImageBlock { .. }) {
                     return result;
                 }

--- a/src/tui_renderer.rs
+++ b/src/tui_renderer.rs
@@ -90,8 +90,20 @@ pub struct RenderedDoc {
 
 impl RenderedDoc {}
 
+/// Configuration for the TUI rendering pass.
+///
+/// Bundled into a struct so new options can be added without changing the
+/// signatures of `render_ast`, `render_node`, and `render_inline`.
+pub struct RenderConfig<'a> {
+    /// Optional syntect theme name for code-block highlighting.
+    pub syntax_theme: Option<&'a str>,
+    /// Whether to emit `InlineMathLine` elements for inline math (`[$…$]`).
+    /// When `false`, inline math is rendered as plain magenta text.
+    pub inline_math: bool,
+}
+
 /// Render an AST root node into a flat list of DocElements.
-pub fn render_ast(ast: &AstNode, syntax_theme: Option<&str>, inline_math: bool) -> RenderedDoc {
+pub fn render_ast(ast: &AstNode, cfg: &RenderConfig<'_>) -> RenderedDoc {
     let mut elements = Vec::new();
     let mut focusables = Vec::new();
     let mut anchors = HashMap::new();
@@ -101,8 +113,7 @@ pub fn render_ast(ast: &AstNode, syntax_theme: Option<&str>, inline_math: bool) 
         &mut focusables,
         &mut anchors,
         0,
-        syntax_theme,
-        inline_math,
+        cfg,
     );
     RenderedDoc {
         elements,
@@ -166,8 +177,7 @@ fn render_node(
     focusables: &mut Vec<FocusableItem>,
     anchors: &mut HashMap<String, usize>,
     indent: usize,
-    syntax_theme: Option<&str>,
-    inline_math: bool,
+    cfg: &RenderConfig<'_>,
 ) {
     match ast.kind() {
         AstNodeKind::Dummy => {
@@ -179,8 +189,7 @@ fn render_node(
                     focusables,
                     anchors,
                     indent,
-                    syntax_theme,
-                    inline_math,
+                    cfg,
                 );
             }
         }
@@ -208,8 +217,7 @@ fn render_node(
                     focusables,
                     anchors,
                     indent,
-                    syntax_theme,
-                    inline_math,
+                    cfg,
                 );
                 // Still render children (nested lines after the block)
                 let children = ast.value().children.lock().unwrap();
@@ -220,8 +228,7 @@ fn render_node(
                         focusables,
                         anchors,
                         indent + 1,
-                        syntax_theme,
-                        inline_math,
+                        cfg,
                     );
                 }
                 return;
@@ -306,7 +313,7 @@ fn render_node(
                     base_style,
                     focusables,
                     elements.len(),
-                    inline_math,
+                    cfg,
                 );
                 match result {
                     InlineResult::ImageBlock { src, alt } => {
@@ -382,8 +389,7 @@ fn render_node(
                     focusables,
                     anchors,
                     indent + 1,
-                    syntax_theme,
-                    inline_math,
+                    cfg,
                 );
             }
         }
@@ -396,8 +402,7 @@ fn render_node(
                     focusables,
                     anchors,
                     indent,
-                    syntax_theme,
-                    inline_math,
+                    cfg,
                 );
             }
         }
@@ -450,7 +455,7 @@ fn render_node(
                 drop(children);
                 let raw_refs: Vec<&str> = raw_lines.iter().map(|s| s.as_str()).collect();
                 let highlighted =
-                    crate::syntax_highlight::highlight_code(lang, &raw_refs, syntax_theme);
+                    crate::syntax_highlight::highlight_code(lang, &raw_refs, cfg.syntax_theme);
                 for (line_spans, _raw) in highlighted.into_iter().zip(raw_lines.iter()) {
                     let mut spans = vec![Span::raw(prefix.clone())];
                     if line_spans.is_empty() {
@@ -548,13 +553,17 @@ fn render_table_row(
         }
         let col_contents = col.value().contents.lock().unwrap();
         for c in col_contents.iter() {
+            let no_inline = RenderConfig {
+                syntax_theme: None,
+                inline_math: false,
+            };
             render_inline(
                 c,
                 &mut spans,
                 Style::default(),
                 focusables,
                 elements.len(),
-                false,
+                &no_inline,
             );
         }
     }
@@ -574,7 +583,7 @@ fn render_inline(
     base_style: Style,
     focusables: &mut Vec<FocusableItem>,
     current_elem_idx: usize,
-    inline_math: bool,
+    cfg: &RenderConfig<'_>,
 ) -> InlineResult {
     match ast.kind() {
         AstNodeKind::Text => {
@@ -680,7 +689,7 @@ fn render_inline(
         }
         AstNodeKind::Math { inline: true } => {
             let contents = ast.value().contents.lock().unwrap();
-            if inline_math {
+            if cfg.inline_math {
                 // Return as InlineMath so the caller can render it as an image
                 let content: String = contents
                     .iter()
@@ -725,7 +734,7 @@ fn render_inline(
                     style,
                     focusables,
                     current_elem_idx,
-                    inline_math,
+                    cfg,
                 );
                 if matches!(result, InlineResult::ImageBlock { .. }) {
                     return result;
@@ -751,7 +760,7 @@ fn render_inline(
                     base_style.fg(Color::DarkGray),
                     focusables,
                     current_elem_idx,
-                    inline_math,
+                    cfg,
                 );
             }
         }

--- a/src/tui_renderer.rs
+++ b/src/tui_renderer.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
+use unicode_width::UnicodeWidthStr;
 
 use crate::parser::{AstNode, AstNodeKind, Property, TaskStatus};
 use crate::utils::get_gyazo_img_src;
@@ -37,6 +38,15 @@ pub struct FocusableItem {
     pub action: LinkAction,
 }
 
+/// A segment within a line that mixes text and inline math.
+#[derive(Debug, Clone)]
+pub enum InlineSegment {
+    /// Styled text spans.
+    Text(Vec<Span<'static>>),
+    /// Inline math expression (raw LaTeX content).
+    Math(String),
+}
+
 /// A single element in the rendered document.
 #[derive(Debug, Clone)]
 pub enum DocElement {
@@ -53,6 +63,11 @@ pub enum DocElement {
     ImageRow(Vec<(String, Option<String>)>, usize),
     /// A math block to render as an image (LaTeX source).
     Math { content: String, indent: usize },
+    /// A line containing inline math segments (text interleaved with math images).
+    InlineMathLine {
+        segments: Vec<InlineSegment>,
+        source_row: usize,
+    },
     /// A blank line.
     Spacer,
 }
@@ -76,7 +91,7 @@ pub struct RenderedDoc {
 impl RenderedDoc {}
 
 /// Render an AST root node into a flat list of DocElements.
-pub fn render_ast(ast: &AstNode, syntax_theme: Option<&str>) -> RenderedDoc {
+pub fn render_ast(ast: &AstNode, syntax_theme: Option<&str>, inline_math: bool) -> RenderedDoc {
     let mut elements = Vec::new();
     let mut focusables = Vec::new();
     let mut anchors = HashMap::new();
@@ -87,6 +102,7 @@ pub fn render_ast(ast: &AstNode, syntax_theme: Option<&str>) -> RenderedDoc {
         &mut anchors,
         0,
         syntax_theme,
+        inline_math,
     );
     RenderedDoc {
         elements,
@@ -102,6 +118,8 @@ enum InlineResult {
     Inline,
     /// An image block that must be emitted as a separate DocElement.
     ImageBlock { src: String, alt: Option<String> },
+    /// An inline math expression (when inline_math rendering is enabled).
+    InlineMath { content: String },
 }
 
 /// Returns true if `spans` contains any non-whitespace text.
@@ -149,12 +167,21 @@ fn render_node(
     anchors: &mut HashMap<String, usize>,
     indent: usize,
     syntax_theme: Option<&str>,
+    inline_math: bool,
 ) {
     match ast.kind() {
         AstNodeKind::Dummy => {
             let children = ast.value().children.lock().unwrap();
             for child in children.iter() {
-                render_node(child, elements, focusables, anchors, indent, syntax_theme);
+                render_node(
+                    child,
+                    elements,
+                    focusables,
+                    anchors,
+                    indent,
+                    syntax_theme,
+                    inline_math,
+                );
             }
         }
         AstNodeKind::Line { properties } | AstNodeKind::QuoteContent { properties } => {
@@ -182,6 +209,7 @@ fn render_node(
                     anchors,
                     indent,
                     syntax_theme,
+                    inline_math,
                 );
                 // Still render children (nested lines after the block)
                 let children = ast.value().children.lock().unwrap();
@@ -193,6 +221,7 @@ fn render_node(
                         anchors,
                         indent + 1,
                         syntax_theme,
+                        inline_math,
                     );
                 }
                 return;
@@ -264,11 +293,21 @@ fn render_node(
             let mut spans = prefix_spans.clone();
             // Buffer for consecutive images (no non-whitespace text between them).
             let mut image_row_buf: Vec<(String, Option<String>)> = Vec::new();
+            // Whether any InlineMath result was returned for this line.
+            let mut has_inline_math = false;
+            // Segments collected when inline math is present.
+            let mut segments: Vec<InlineSegment> = Vec::new();
 
             let contents = ast.value().contents.lock().unwrap();
             for content in contents.iter() {
-                let result =
-                    render_inline(content, &mut spans, base_style, focusables, elements.len());
+                let result = render_inline(
+                    content,
+                    &mut spans,
+                    base_style,
+                    focusables,
+                    elements.len(),
+                    inline_math,
+                );
                 match result {
                     InlineResult::ImageBlock { src, alt } => {
                         // If spans have real text, flush them before starting an image group
@@ -286,6 +325,17 @@ fn render_node(
                             spans = vec![Span::raw("  ".repeat(indent + 1))];
                         }
                         image_row_buf.push((src, alt));
+                    }
+                    InlineResult::InlineMath {
+                        content: math_content,
+                    } => {
+                        has_inline_math = true;
+                        // Flush any accumulated spans into a Text segment
+                        if !spans.is_empty() {
+                            segments.push(InlineSegment::Text(std::mem::take(&mut spans)));
+                            spans = Vec::new();
+                        }
+                        segments.push(InlineSegment::Math(math_content));
                     }
                     InlineResult::Inline => {
                         // Non-image content — flush any pending image row first
@@ -308,8 +358,20 @@ fn render_node(
                 }
             }
 
-            // Flush remaining spans (always emit to preserve blank lines)
-            elements.push(DocElement::TextLine(Line::from(spans), ast.location().row));
+            // Emit the line: InlineMathLine if inline math was found, else plain TextLine
+            if has_inline_math {
+                // Flush any remaining spans as a final Text segment
+                if !spans.is_empty() {
+                    segments.push(InlineSegment::Text(spans));
+                }
+                elements.push(DocElement::InlineMathLine {
+                    segments,
+                    source_row: ast.location().row,
+                });
+            } else {
+                // Flush remaining spans (always emit to preserve blank lines)
+                elements.push(DocElement::TextLine(Line::from(spans), ast.location().row));
+            }
 
             // Children (nested lines)
             let children = ast.value().children.lock().unwrap();
@@ -321,13 +383,22 @@ fn render_node(
                     anchors,
                     indent + 1,
                     syntax_theme,
+                    inline_math,
                 );
             }
         }
         AstNodeKind::Quote => {
             let children = ast.value().children.lock().unwrap();
             for child in children.iter() {
-                render_node(child, elements, focusables, anchors, indent, syntax_theme);
+                render_node(
+                    child,
+                    elements,
+                    focusables,
+                    anchors,
+                    indent,
+                    syntax_theme,
+                    inline_math,
+                );
             }
         }
         AstNodeKind::Math { inline } => {
@@ -477,16 +548,24 @@ fn render_table_row(
         }
         let col_contents = col.value().contents.lock().unwrap();
         for c in col_contents.iter() {
-            render_inline(c, &mut spans, Style::default(), focusables, elements.len());
+            render_inline(
+                c,
+                &mut spans,
+                Style::default(),
+                focusables,
+                elements.len(),
+                false,
+            );
         }
     }
     spans.push(Span::styled(" │", Style::default().fg(Color::DarkGray)));
     elements.push(DocElement::TextLine(Line::from(spans), source_row));
 }
 
-/// Count total character width of accumulated spans.
+/// Count total display column width of accumulated spans (Unicode-aware).
+/// CJK and other double-width characters each count as 2 columns.
 fn spans_char_width(spans: &[Span<'_>]) -> usize {
-    spans.iter().map(|s| s.content.chars().count()).sum()
+    spans.iter().map(|s| s.content.width()).sum()
 }
 
 fn render_inline(
@@ -495,6 +574,7 @@ fn render_inline(
     base_style: Style,
     focusables: &mut Vec<FocusableItem>,
     current_elem_idx: usize,
+    inline_math: bool,
 ) -> InlineResult {
     match ast.kind() {
         AstNodeKind::Text => {
@@ -600,11 +680,22 @@ fn render_inline(
         }
         AstNodeKind::Math { inline: true } => {
             let contents = ast.value().contents.lock().unwrap();
-            for content in contents.iter() {
-                spans.push(Span::styled(
-                    content.extract_str().to_string(),
-                    base_style.fg(Color::Magenta),
-                ));
+            if inline_math {
+                // Return as InlineMath so the caller can render it as an image
+                let content: String = contents
+                    .iter()
+                    .map(|c| c.extract_str().to_string())
+                    .collect::<Vec<_>>()
+                    .join("");
+                return InlineResult::InlineMath { content };
+            } else {
+                // Fallback: display raw LaTeX as magenta text
+                for content in contents.iter() {
+                    spans.push(Span::styled(
+                        content.extract_str().to_string(),
+                        base_style.fg(Color::Magenta),
+                    ));
+                }
             }
         }
         AstNodeKind::Decoration {
@@ -628,7 +719,14 @@ fn render_inline(
             }
             let contents = ast.value().contents.lock().unwrap();
             for content in contents.iter() {
-                let result = render_inline(content, spans, style, focusables, current_elem_idx);
+                let result = render_inline(
+                    content,
+                    spans,
+                    style,
+                    focusables,
+                    current_elem_idx,
+                    inline_math,
+                );
                 if matches!(result, InlineResult::ImageBlock { .. }) {
                     return result;
                 }
@@ -653,6 +751,7 @@ fn render_inline(
                     base_style.fg(Color::DarkGray),
                     focusables,
                     current_elem_idx,
+                    inline_math,
                 );
             }
         }


### PR DESCRIPTION
## Summary
- render inline math in `patto-preview-tui` via Typst-backed images
- wrap mixed text and inline math correctly while keeping inline math atomic
- cache inline math dimensions for stable scrolling/layout and preserve text fallback when graphics are unavailable

## Notes
- included a small follow-up fix to reuse the shared inline math cache-key helper and trim a couple of local warnings
