### PR TITLE
fix: patto_tasks_review shows inflated time_spent

### DIFF
--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -2251,4 +2251,57 @@ mod tests {
         let label5 = task_label(line5);
         assert_eq!(label5, "[牛乳🔗] 牛乳を買う");
     }
+
+    // ── stale started_at diagnostics ────────────────────────────────────────
+
+    #[test]
+    fn test_stale_started_at_warn_on_done_task() {
+        // Done task with started_at still present → should emit stale-started-at warning.
+        let (_ast, diags) = parse_text(
+            "buy milk {@task status=done due=2026-06-01 completed_at=2026-06-01T11:00 started_at=2026-06-01T09:00 time_spent=2h}\n",
+        );
+        let stale: Vec<_> = diags
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stale-started-at".into())))
+            .collect();
+        assert_eq!(
+            stale.len(),
+            1,
+            "expected one stale-started-at diagnostic, got: {:?}",
+            diags
+        );
+        assert_eq!(stale[0].severity, Some(DiagnosticSeverity::WARNING));
+    }
+
+    #[test]
+    fn test_stale_started_at_no_warn_on_doing_task() {
+        // Doing task with started_at is legitimate — must NOT emit the warning.
+        let (_ast, diags) = parse_text(
+            "buy milk {@task status=doing due=2026-06-01 started_at=2026-06-01T09:00}\n",
+        );
+        let stale: Vec<_> = diags
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stale-started-at".into())))
+            .collect();
+        assert!(
+            stale.is_empty(),
+            "doing task with started_at should not produce stale-started-at warning"
+        );
+    }
+
+    #[test]
+    fn test_stale_started_at_no_warn_on_done_task_without_started_at() {
+        // Clean done task (no started_at) → no warning.
+        let (_ast, diags) = parse_text(
+            "buy milk {@task status=done due=2026-06-01 completed_at=2026-06-01T11:00 time_spent=2h}\n",
+        );
+        let stale: Vec<_> = diags
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stale-started-at".into())))
+            .collect();
+        assert!(
+            stale.is_empty(),
+            "done task without started_at should not produce stale-started-at warning"
+        );
+    }
 }

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -119,6 +119,7 @@ fn parse_text(text: &str) -> (AstNode, Vec<Diagnostic>) {
         .collect();
 
     diagnostics.extend(gather_malformed_command_diagnostics(text));
+    diagnostics.extend(gather_stale_started_at_diagnostics(&ast));
     (ast, diagnostics)
 }
 
@@ -183,6 +184,57 @@ fn gather_malformed_command_diagnostics(text: &str) -> Vec<Diagnostic> {
         }
     }
     diags
+}
+
+/// Walk the AST and emit a WARNING diagnostic for every done task that still has
+/// a `started_at` field.  Such a field is stale: the clock-out transition should
+/// have removed it and accumulated elapsed time into `time_spent`.  Leaving it in
+/// place can mislead tooling into double-counting elapsed time.
+fn gather_stale_started_at_diagnostics(root: &AstNode) -> Vec<Diagnostic> {
+    let mut diags = Vec::new();
+    gather_stale_started_at_diagnostics_impl(root, &mut diags);
+    diags
+}
+
+fn gather_stale_started_at_diagnostics_impl(node: &AstNode, diags: &mut Vec<Diagnostic>) {
+    if let AstNodeKind::Line { ref properties } = node.kind() {
+        for prop in properties {
+            if let Property::Task {
+                status,
+                started_at: Some(_),
+                location,
+                ..
+            } = prop
+            {
+                if matches!(status, TaskStatus::Done) {
+                    let row = node.location().row as u32;
+                    let line_text = node.extract_str();
+                    let col_start = utf16_from_byte_idx(line_text, location.span.0) as u32;
+                    let col_end =
+                        utf16_from_byte_idx(line_text, location.span.1.min(line_text.len())) as u32;
+                    diags.push(Diagnostic {
+                        range: Range::new(
+                            Position::new(row, col_start),
+                            Position::new(row, col_end),
+                        ),
+                        severity: Some(DiagnosticSeverity::WARNING),
+                        code: Some(NumberOrString::String("stale-started-at".into())),
+                        code_description: None,
+                        source: Some("patto".into()),
+                        message: "Done task has a stale started_at field. \
+                            The time_spent field already accounts for all accumulated time. \
+                            Remove started_at= to silence this warning."
+                            .into(),
+                        ..Diagnostic::default()
+                    });
+                    break; // at most one Task property per line
+                }
+            }
+        }
+    }
+    for child in node.value().children.lock().unwrap().iter() {
+        gather_stale_started_at_diagnostics_impl(child, diags);
+    }
 }
 
 fn gather_anchors(parent: &AstNode, anchors: &mut Vec<String>) {

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -1193,10 +1193,13 @@ impl LanguageServer for Backend {
                 let ret = json!(tasks
                     .iter()
                     .map(|(uri, line, date)| {
-                        let mut info =
+                        let info =
                             task_information(uri, line, &crate::parser::Deadline::Date(*date));
                         // Override completed_at with the authoritative value from repository
-                        // (already set by task_information, but ensure the date string matches)
+                        // (already set by task_information, but ensure the date string matches).
+                        // started_at is intentionally omitted: for a done task it is stale and
+                        // must not be used to compute additional elapsed time on the review side.
+                        // The time_spent field already contains the correct accumulated total.
                         json!({
                             "location":    info.location,
                             "text":        info.text,
@@ -1204,7 +1207,6 @@ impl LanguageServer for Backend {
                             "due":         info.due,
                             "scheduled":   info.scheduled,
                             "completed_at": date.format("%Y-%m-%d").to_string(),
-                            "started_at":  info.started_at,
                             "time_spent":  info.time_spent,
                         })
                     })

--- a/src/lsp/task_edits.rs
+++ b/src/lsp/task_edits.rs
@@ -280,7 +280,7 @@ fn elapsed_since(
     use crate::parser::Deadline;
     let start = match started_at.as_ref()? {
         Deadline::DateTime(dt) => *dt,
-        Deadline::Date(d) => d.and_hms_opt(0, 0, 0)?,
+        Deadline::Date(_) => return None,
         Deadline::Uninterpretable(_) => return None,
     };
     let secs = (now - start).num_seconds();

--- a/tests/lsp_task_time_tracking.rs
+++ b/tests/lsp_task_time_tracking.rs
@@ -378,3 +378,52 @@ fn test_doing_to_todo_via_keystroke_simulation() {
         edit.new_text
     );
 }
+
+// ─── Bare-date started_at tests ───────────────────────────────────────────────
+
+/// When started_at is a bare date (no time component), elapsed_since must return
+/// None.  The clock-out transition should therefore produce no time_spent edit,
+/// leaving any existing time_spent unchanged and started_at untouched.
+#[tokio::test]
+async fn test_bare_date_started_at_produces_no_elapsed() {
+    let _workspace = TestWorkspace::new();
+    // started_at=2026-05-19 (date only, no T time component).
+    // Old snapshot is Doing with that bare-date started_at; new snapshot is Todo.
+    let edits = edits_for(
+        "buy milk {@task status=doing due=2026-06-01 started_at=2026-05-19}\n",
+        "buy milk {@task status=todo due=2026-06-01}\n",
+    );
+    // No elapsed can be computed from a bare date — no edit should be generated.
+    assert!(
+        edits.is_empty(),
+        "bare-date started_at should produce no clock-out edit, got: {:?}",
+        edits
+    );
+}
+
+/// Same scenario but clocking out directly to done: no elapsed should be added,
+/// but completed_at must still be written.
+#[tokio::test]
+async fn test_bare_date_started_at_done_only_sets_completed_at() {
+    let _workspace = TestWorkspace::new();
+    let edits = edits_for(
+        "buy milk {@task status=doing due=2026-06-01 started_at=2026-05-19}\n",
+        "buy milk {@task status=done due=2026-06-01}\n",
+    );
+    assert_eq!(
+        edits.len(),
+        1,
+        "one edit expected for doing→done even with bare-date started_at"
+    );
+    let edit = &edits[0];
+    assert!(
+        edit.new_text.contains("completed_at="),
+        "edit should set completed_at, got: {}",
+        edit.new_text
+    );
+    assert!(
+        !edit.new_text.contains("time_spent="),
+        "no time_spent should be added when started_at is a bare date, got: {}",
+        edit.new_text
+    );
+}


### PR DESCRIPTION
## Problem

`patto_tasks_review` displayed a much larger `time_spent` than what was actually worked.

### Root causes

1. **Bare-date `started_at` inflated elapsed time** (`task_edits.rs`)
   When `started_at` was stored as a bare date (`YYYY-MM-DD`, no time component), `elapsed_since` substituted midnight (`00:00:00`) as the clock-in time. Clocking out at e.g. 14:30 would compute 14h30m of elapsed and bake that permanently into `time_spent`.

2. **`tasks_review` response exposed stale `started_at`** (`backend.rs`)
   The `experimental/tasks_review` JSON included `started_at` for done tasks. For a done task this field is stale; `time_spent` is the sole accumulated total.

## Changes

### `src/lsp/task_edits.rs`
- `elapsed_since`: return `None` for `Deadline::Date` (bare date) instead of using midnight. No elapsed is computed when the precise clock-in time is unknown.

### `src/lsp/backend.rs`
- `experimental/tasks_review` handler: omit `started_at` from the serialised response for done tasks.
- New `gather_stale_started_at_diagnostics`: walks the AST and emits a `WARNING` (code `stale-started-at`) on any done task that still has `started_at` present on disk, so existing dirty files surface the problem visibly without being auto-modified.

### Tests
- 3 unit tests in `backend.rs` for the stale-started-at diagnostic (positive + two negative cases)
- 2 integration tests in `lsp_task_time_tracking.rs` for the bare-date elapsed fix