### PR TITLE
fix: update TypeScript target to ES2022 to support private identifier…

### DIFF
--- a/patto-preview-ui/tsconfig.json
+++ b/patto-preview-ui/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": [
       "ES2020",


### PR DESCRIPTION
…s in rolldown

The build was failing with 'error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.' This error occurred because the rolldown package uses private identifiers (ES2022 feature) but the TypeScript target was set to ES2020.

Updating the target to ES2022 resolves this compilation error.